### PR TITLE
Add Pacakge.swift for easy run and debug from Xcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ DerivedData/
 *.ipa
 *.dSYM.zip
 *.dSYM
+.swiftpm/
 
 # Temporary files
 /tmp/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "Posturr",
+    platforms: [
+        .macOS(.v13)
+    ],
+    targets: [
+        .executableTarget(
+            name: "Posturr",
+            path: ".",
+            sources: ["main.swift"],
+            linkerSettings: [
+                .linkedFramework("AppKit"),
+                .linkedFramework("AVFoundation"),
+                .linkedFramework("Vision"),
+                .linkedFramework("CoreImage")
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
I'm used to working on Swift and macOS software from Xcode and wanted to be able to use the Xcode debugger and other tools. Due to how the project is set up, it made sense to just add a Package.swift file to use Xcode's SwiftPM support rather than making an Xcode Project file which is more complex.

I was able to successfully run from Xcode, see print statements, and use breakpoints.