### PR TITLE
Add solid color warning style

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1216,8 +1216,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // Only privacy blur, no posture warning visual
             targetBlurRadius = Int32(privacyBlurIntensity * 64)
             warningOverlayManager.targetIntensity = 0
-        case .vignette, .border:
-            // Privacy uses blur, posture uses vignette/border overlay
+        case .vignette, .border, .solid:
+            // Privacy uses blur, posture uses vignette/border/solid overlay
             targetBlurRadius = Int32(privacyBlurIntensity * 64)
             warningOverlayManager.targetIntensity = postureWarningIntensity
         }

--- a/Sources/Models.swift
+++ b/Sources/Models.swift
@@ -14,13 +14,14 @@ enum WarningMode: String, CaseIterable {
     case blur = "blur"
     case vignette = "vignette"
     case border = "border"
+    case solid = "solid"
     case none = "none"
 
     /// Whether this mode uses the WarningOverlayManager for posture warnings.
-    /// Vignette and border use the overlay system; blur and none do not.
+    /// Vignette, border, and solid use the overlay system; blur and none do not.
     var usesWarningOverlay: Bool {
         switch self {
-        case .vignette, .border: return true
+        case .vignette, .border, .solid: return true
         case .blur, .none: return false
         }
     }

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -214,7 +214,7 @@ struct WarningStylePicker: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            ForEach([WarningMode.blur, .vignette, .border, .none], id: \.self) { mode in
+            ForEach([WarningMode.blur, .vignette, .border, .solid, .none], id: \.self) { mode in
                 Button(action: { selection = mode }) {
                     Text(mode.displayName)
                         .font(.system(size: 11, weight: selection == mode ? .semibold : .regular))
@@ -244,6 +244,7 @@ extension WarningMode {
         case .blur: return "Blur"
         case .vignette: return "Vignette"
         case .border: return "Border"
+        case .solid: return "Solid"
         case .none: return "None"
         }
     }


### PR DESCRIPTION
New warning mode that fades the entire screen to a solid color, providing a more aggressive visual cue than vignette or border styles.

Closes #39 