### PR TITLE
Adding support for user-defined profiles

### DIFF
--- a/Sources/Models.swift
+++ b/Sources/Models.swift
@@ -109,7 +109,7 @@ enum WarningDefaults {
 
 // MARK: - Warning Mode
 
-enum WarningMode: String, CaseIterable {
+enum WarningMode: String, CaseIterable, Codable {
     case blur = "blur"
     case vignette = "vignette"
     case border = "border"
@@ -128,7 +128,7 @@ enum WarningMode: String, CaseIterable {
 
 // MARK: - Detection Mode
 
-enum DetectionMode: String, CaseIterable {
+enum DetectionMode: String, CaseIterable, Codable {
     case responsive = "responsive"  // 10 fps - best accuracy (default)
     case balanced = "balanced"      // 4 fps - good balance
     case performance = "performance" // 2 fps - best battery life
@@ -160,6 +160,8 @@ enum SettingsKeys {
     static let pauseOnTheGo = "pauseOnTheGo"
     static let lastCameraID = "lastCameraID"
     static let profiles = "profiles"
+    static let settingsProfiles = "settingsProfiles"
+    static let currentSettingsProfileID = "currentSettingsProfileID"
     static let warningMode = "warningMode"
     static let warningColor = "warningColor"
     static let warningOnsetDelay = "blurOnsetDelay"  // Keep key for backward compatibility
@@ -223,6 +225,204 @@ struct ProfileData: Codable {
     let neutralY: CGFloat
     let postureRange: CGFloat
     let cameraID: String
+}
+
+// MARK: - Settings Profile
+struct SettingsProfile: Codable, Identifiable, Equatable {
+    let id: String
+    var name: String
+    var warningMode: WarningMode
+    var warningColorData: Data
+    var deadZone: Double
+    var intensity: Double
+    var warningOnsetDelay: Double
+    var detectionMode: DetectionMode
+
+    var warningColor: NSColor {
+        if let color = try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSColor.self, from: warningColorData) {
+            return color
+        }
+        return WarningDefaults.color
+    }
+
+    static func encodedColorData(from color: NSColor) -> Data {
+        (try? NSKeyedArchiver.archivedData(withRootObject: color, requiringSecureCoding: false)) ?? Data()
+    }
+}
+
+// MARK: - Settings Profile Manager
+final class SettingsProfileManager {
+    private(set) var settingsProfiles: [SettingsProfile] = []
+    private(set) var currentSettingsProfileID: String?
+    private let defaultIntensity: Double = 1.0
+    private let defaultDeadZone: Double = 0.03
+    private let defaultWarningOnsetDelay: Double = 0.0
+
+    var activeProfile: SettingsProfile? {
+        guard let profileID = currentSettingsProfileID else { return nil }
+        return settingsProfiles.first(where: { $0.id == profileID })
+    }
+
+    func loadProfiles() {
+        guard settingsProfiles.isEmpty else { return }
+        let defaults = UserDefaults.standard
+        if let data = defaults.data(forKey: SettingsKeys.settingsProfiles),
+           let profiles = try? JSONDecoder().decode([SettingsProfile].self, from: data),
+           !profiles.isEmpty {
+            settingsProfiles = profiles
+            let savedID = defaults.string(forKey: SettingsKeys.currentSettingsProfileID)
+            let selectedProfile = profiles.first(where: { $0.id == savedID }) ?? profiles.first
+            currentSettingsProfileID = selectedProfile?.id
+            return
+        }
+
+        let legacyIntensity = doubleOrDefault(forKey: SettingsKeys.intensity, defaultValue: defaultIntensity)
+        let legacyDeadZone = doubleOrDefault(forKey: SettingsKeys.deadZone, defaultValue: defaultDeadZone)
+        var legacyWarningMode = WarningMode.blur
+        var legacyWarningColor = WarningDefaults.color
+        var legacyWarningOnsetDelay = defaultWarningOnsetDelay
+        var legacyDetectionMode = DetectionMode.balanced
+
+        if let modeString = defaults.string(forKey: SettingsKeys.warningMode),
+           let mode = WarningMode(rawValue: modeString) {
+            legacyWarningMode = mode
+        }
+        if let colorData = defaults.data(forKey: SettingsKeys.warningColor),
+           let color = try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSColor.self, from: colorData) {
+            legacyWarningColor = color
+        }
+        legacyWarningOnsetDelay = doubleOrDefault(forKey: SettingsKeys.warningOnsetDelay, defaultValue: defaultWarningOnsetDelay)
+        if let modeString = defaults.string(forKey: SettingsKeys.detectionMode),
+           let mode = DetectionMode(rawValue: modeString) {
+            legacyDetectionMode = mode
+        }
+
+        let defaultProfile = SettingsProfile(
+            id: UUID().uuidString,
+            name: "Default",
+            warningMode: legacyWarningMode,
+            warningColorData: SettingsProfile.encodedColorData(from: legacyWarningColor),
+            deadZone: legacyDeadZone,
+            intensity: legacyIntensity,
+            warningOnsetDelay: legacyWarningOnsetDelay,
+            detectionMode: legacyDetectionMode
+        )
+        settingsProfiles = [defaultProfile]
+        currentSettingsProfileID = defaultProfile.id
+        saveProfiles()
+        if defaults.object(forKey: SettingsKeys.intensity) != nil
+            || defaults.object(forKey: SettingsKeys.deadZone) != nil
+            || defaults.object(forKey: SettingsKeys.warningMode) != nil
+            || defaults.object(forKey: SettingsKeys.warningColor) != nil
+            || defaults.object(forKey: SettingsKeys.warningOnsetDelay) != nil
+            || defaults.object(forKey: SettingsKeys.detectionMode) != nil {
+            clearLegacyProfileKeys()
+        }
+    }
+
+    func ensureProfilesLoaded() {
+        if settingsProfiles.isEmpty {
+            loadProfiles()
+        }
+    }
+
+    func profilesState() -> (profiles: [SettingsProfile], selectedID: String?) {
+        (settingsProfiles, currentSettingsProfileID)
+    }
+
+    func updateActiveProfile(
+        warningMode: WarningMode? = nil,
+        warningColor: NSColor? = nil,
+        deadZone: Double? = nil,
+        intensity: Double? = nil,
+        warningOnsetDelay: Double? = nil,
+        detectionMode: DetectionMode? = nil
+    ) {
+        guard let profileID = currentSettingsProfileID,
+              let index = settingsProfiles.firstIndex(where: { $0.id == profileID }) else {
+            return
+        }
+        var profile = settingsProfiles[index]
+        if let warningMode = warningMode {
+            profile.warningMode = warningMode
+        }
+        if let warningColor = warningColor {
+            profile.warningColorData = SettingsProfile.encodedColorData(from: warningColor)
+        }
+        if let deadZone = deadZone {
+            profile.deadZone = deadZone
+        }
+        if let intensity = intensity {
+            profile.intensity = intensity
+        }
+        if let warningOnsetDelay = warningOnsetDelay {
+            profile.warningOnsetDelay = warningOnsetDelay
+        }
+        if let detectionMode = detectionMode {
+            profile.detectionMode = detectionMode
+        }
+        settingsProfiles[index] = profile
+        saveProfiles()
+    }
+
+    func selectProfile(id: String) -> SettingsProfile? {
+        guard let profile = settingsProfiles.first(where: { $0.id == id }) else { return nil }
+        currentSettingsProfileID = id
+        saveProfiles()
+        return profile
+    }
+
+    func createProfile(
+        named name: String,
+        warningMode: WarningMode,
+        warningColor: NSColor,
+        deadZone: Double,
+        intensity: Double,
+        warningOnsetDelay: Double,
+        detectionMode: DetectionMode
+    ) -> SettingsProfile {
+        let profile = SettingsProfile(
+            id: UUID().uuidString,
+            name: name,
+            warningMode: warningMode,
+            warningColorData: SettingsProfile.encodedColorData(from: warningColor),
+            deadZone: deadZone,
+            intensity: intensity,
+            warningOnsetDelay: warningOnsetDelay,
+            detectionMode: detectionMode
+        )
+        settingsProfiles.append(profile)
+        currentSettingsProfileID = profile.id
+        saveProfiles()
+        return profile
+    }
+
+    private func saveProfiles() {
+        let defaults = UserDefaults.standard
+        if let data = try? JSONEncoder().encode(settingsProfiles) {
+            defaults.set(data, forKey: SettingsKeys.settingsProfiles)
+        }
+        if let profileID = currentSettingsProfileID {
+            defaults.set(profileID, forKey: SettingsKeys.currentSettingsProfileID)
+        }
+    }
+
+    private func doubleOrDefault(forKey key: String, defaultValue: Double) -> Double {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: key) != nil else { return defaultValue }
+        return defaults.double(forKey: key)
+    }
+
+    private func clearLegacyProfileKeys() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: SettingsKeys.intensity)
+        defaults.removeObject(forKey: SettingsKeys.deadZone)
+        defaults.removeObject(forKey: SettingsKeys.warningMode)
+        defaults.removeObject(forKey: SettingsKeys.warningColor)
+        defaults.removeObject(forKey: SettingsKeys.warningOnsetDelay)
+        defaults.removeObject(forKey: SettingsKeys.detectionMode)
+    }
+
 }
 
 // MARK: - Pause Reason


### PR DESCRIPTION
Made the changes for myself, thought might be useful for the project - feel free to discard if not!

Intentionally left out camera/airpods & device from the config due to the interaction with the automated selection of calibration depending on the displays.

Lmk if you want to add some docs in if the feature proves useful