### PR TITLE
Add "Check for Updates" menu item

### DIFF
--- a/Sources/MenuBar.swift
+++ b/Sources/MenuBar.swift
@@ -14,6 +14,7 @@ final class MenuBarManager {
     var onRecalibrate: (() -> Void)?
     var onShowAnalytics: (() -> Void)?
     var onOpenSettings: (() -> Void)?
+    var onCheckForUpdates: (() -> Void)?
     var onQuit: (() -> Void)?
 
     func setup() {
@@ -56,6 +57,12 @@ final class MenuBarManager {
         settingsItem.target = self
         settingsItem.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: L("menu.settings"))
         menu.addItem(settingsItem)
+
+        // Check for Updates
+        let updateItem = NSMenuItem(title: L("menu.checkForUpdates"), action: #selector(handleCheckForUpdates), keyEquivalent: "")
+        updateItem.target = self
+        updateItem.image = NSImage(systemSymbolName: "arrow.triangle.2.circlepath", accessibilityDescription: L("menu.checkForUpdates"))
+        menu.addItem(updateItem)
 
         menu.addItem(NSMenuItem.separator())
 
@@ -108,6 +115,10 @@ final class MenuBarManager {
 
     @objc private func handleOpenSettings() {
         onOpenSettings?()
+    }
+
+    @objc private func handleCheckForUpdates() {
+        onCheckForUpdates?()
     }
 
     @objc private func handleQuit() {

--- a/Sources/Resources/de.lproj/Localizable.strings
+++ b/Sources/Resources/de.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "menu.analytics" = "Statistiken";
 "menu.settings" = "Einstellungen";
 "menu.quit" = "Beenden";
+"menu.checkForUpdates" = "Nach Updates suchen...";
 
 // MARK: - App Menu (PosturrMain.swift)
 
@@ -181,6 +182,17 @@
 "onboarding.unavailable" = "Nicht verfügbar";
 "onboarding.continue" = "Weiter";
 
+// MARK: - Update Check (AppDelegate.swift)
+
+"update.available" = "Update verfügbar";
+"update.availableMessage" = "Posturr %@ ist verfügbar. Sie verwenden derzeit eine ältere Version.";
+"update.download" = "Herunterladen";
+"update.upToDate" = "Sie sind auf dem neuesten Stand";
+"update.upToDateMessage" = "Posturr %@ ist die neueste Version.";
+"update.checkFailed" = "Update-Prüfung fehlgeschlagen";
+"update.checkFailedMessage" = "Updates konnten nicht geprüft werden. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.";
+
 // MARK: - Common
 
 "common.cancel" = "Abbrechen";
+"common.ok" = "OK";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "menu.analytics" = "Analytics";
 "menu.settings" = "Settings";
 "menu.quit" = "Quit";
+"menu.checkForUpdates" = "Check for Updates...";
 
 // MARK: - App Menu (PosturrMain.swift)
 
@@ -181,6 +182,17 @@
 "onboarding.unavailable" = "Unavailable";
 "onboarding.continue" = "Continue";
 
+// MARK: - Update Check (AppDelegate.swift)
+
+"update.available" = "Update Available";
+"update.availableMessage" = "Posturr %@ is available. You are currently running an older version.";
+"update.download" = "Download";
+"update.upToDate" = "You're Up to Date";
+"update.upToDateMessage" = "Posturr %@ is the latest version.";
+"update.checkFailed" = "Update Check Failed";
+"update.checkFailedMessage" = "Could not check for updates. Please check your internet connection and try again.";
+
 // MARK: - Common
 
 "common.cancel" = "Cancel";
+"common.ok" = "OK";

--- a/Sources/Resources/es.lproj/Localizable.strings
+++ b/Sources/Resources/es.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "menu.analytics" = "Estadísticas";
 "menu.settings" = "Ajustes";
 "menu.quit" = "Salir";
+"menu.checkForUpdates" = "Buscar actualizaciones...";
 
 // MARK: - App Menu (PosturrMain.swift)
 
@@ -181,6 +182,17 @@
 "onboarding.unavailable" = "No disponible";
 "onboarding.continue" = "Continuar";
 
+// MARK: - Update Check (AppDelegate.swift)
+
+"update.available" = "Actualización disponible";
+"update.availableMessage" = "Posturr %@ está disponible. Actualmente tienes una versión anterior.";
+"update.download" = "Descargar";
+"update.upToDate" = "Estás al día";
+"update.upToDateMessage" = "Posturr %@ es la última versión.";
+"update.checkFailed" = "Error al buscar actualizaciones";
+"update.checkFailedMessage" = "No se pudieron buscar actualizaciones. Comprueba tu conexión a Internet e inténtalo de nuevo.";
+
 // MARK: - Common
 
 "common.cancel" = "Cancelar";
+"common.ok" = "OK";

--- a/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Resources/fr.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "menu.analytics" = "Statistiques";
 "menu.settings" = "Réglages";
 "menu.quit" = "Quitter";
+"menu.checkForUpdates" = "Rechercher les mises à jour...";
 
 // MARK: - App Menu (PosturrMain.swift)
 
@@ -181,6 +182,17 @@
 "onboarding.unavailable" = "Indisponible";
 "onboarding.continue" = "Continuer";
 
+// MARK: - Update Check (AppDelegate.swift)
+
+"update.available" = "Mise à jour disponible";
+"update.availableMessage" = "Posturr %@ est disponible. Vous utilisez actuellement une version antérieure.";
+"update.download" = "Télécharger";
+"update.upToDate" = "Vous êtes à jour";
+"update.upToDateMessage" = "Posturr %@ est la dernière version.";
+"update.checkFailed" = "Échec de la vérification";
+"update.checkFailedMessage" = "Impossible de vérifier les mises à jour. Vérifiez votre connexion Internet et réessayez.";
+
 // MARK: - Common
 
 "common.cancel" = "Annuler";
+"common.ok" = "OK";

--- a/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Resources/ja.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "menu.analytics" = "統計";
 "menu.settings" = "設定";
 "menu.quit" = "終了";
+"menu.checkForUpdates" = "アップデートを確認...";
 
 // MARK: - App Menu (PosturrMain.swift)
 
@@ -181,6 +182,17 @@
 "onboarding.unavailable" = "利用不可";
 "onboarding.continue" = "続ける";
 
+// MARK: - Update Check (AppDelegate.swift)
+
+"update.available" = "アップデートがあります";
+"update.availableMessage" = "Posturr %@ が利用可能です。現在、古いバージョンを使用しています。";
+"update.download" = "ダウンロード";
+"update.upToDate" = "最新の状態です";
+"update.upToDateMessage" = "Posturr %@ は最新バージョンです。";
+"update.checkFailed" = "アップデートの確認に失敗";
+"update.checkFailedMessage" = "アップデートを確認できませんでした。インターネット接続を確認して、もう一度お試しください。";
+
 // MARK: - Common
 
 "common.cancel" = "キャンセル";
+"common.ok" = "OK";

--- a/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "menu.analytics" = "统计";
 "menu.settings" = "设置";
 "menu.quit" = "退出";
+"menu.checkForUpdates" = "检查更新...";
 
 // MARK: - App Menu (PosturrMain.swift)
 
@@ -181,6 +182,17 @@
 "onboarding.unavailable" = "不可用";
 "onboarding.continue" = "继续";
 
+// MARK: - Update Check (AppDelegate.swift)
+
+"update.available" = "有可用更新";
+"update.availableMessage" = "Posturr %@ 已发布。您当前使用的是旧版本。";
+"update.download" = "下载";
+"update.upToDate" = "已是最新版本";
+"update.upToDateMessage" = "Posturr %@ 是最新版本。";
+"update.checkFailed" = "检查更新失败";
+"update.checkFailedMessage" = "无法检查更新。请检查您的网络连接后重试。";
+
 // MARK: - Common
 
 "common.cancel" = "取消";
+"common.ok" = "好";


### PR DESCRIPTION
**Summary**

- Add a "Check for Updates..." menu item to the status bar dropdown menu
- Queries the Apple App Store (iTunes Lookup API) to determine if a newer version is available
- Smart download routing: App Store users are directed to the App Store page, while direct-distribution users are directed to GitHub Releases
- Fully localized across all 6 supported languages (English, German, French, Spanish, Japanese, Simplified Chinese)

**How It Works**

1. User clicks "Check for Updates..." from the menu bar dropdown
2. The app hits Apple's iTunes Lookup API to fetch the latest published version
3. Compares against the running app's version using semantic versioning
4. Displays one of three alerts:
   - Update available — with a "Download" button pointing to the right source
   - Up to date — confirms the user is on the latest 

**Caveats**

If a GitHub release is published with a newer version than what's currently on the App Store (e.g., during the App Store review period), direct-distribution users would not be notified until the App Store version catches up. This is a reasonable tradeoff since it avoids false positives in the other direction.

The version source is determined at compile time via the APP_STORE flag — builds produced with ./build.sh --appstore route to the App Store, while standard builds (./build.sh) fall back to the GitHub Releases page. This ensures users who installed via GitHub or Homebrew aren't sent to the App Store unnecessarily, and can update through the same channel they originally used.