### PR TITLE
Fix blur staying on screen after disabling while away

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -181,8 +181,10 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         os_log(.info, log: log, "State transition: %{public}@ -> %{public}@", String(describing: oldState), String(describing: newState))
         syncDetectorToState()
         if !newState.isActive {
-            targetBlurRadius = 0
+            isCurrentlyAway = false
+            isCurrentlySlouching = false
             postureWarningIntensity = 0
+            clearBlur()
         }
         if newState == .monitoring {
             applyActiveSettingsProfile()


### PR DESCRIPTION
## Summary

Fixes #60. When Posturr is disabled (via keyboard shortcut or menu) while the user is in "away" status, the screen blur remained visible.

**Root cause:** `handleStateTransition` set `targetBlurRadius = 0`, but left `isCurrentlyAway = true`. The 33ms `updateBlur()` timer then recalculated `targetBlurRadius` from `isCurrentlyAway` on every tick, immediately overwriting the zero.

**Fix:** Reset `isCurrentlyAway` and `isCurrentlySlouching` when transitioning to a non-active state, and call `clearBlur()` for immediate visual feedback.

## Test plan

- [ ] Enable "Blur when away" in settings
- [ ] Walk out of camera view (trigger away/blur state)
- [ ] Disable Posturr via keyboard shortcut → blur should clear immediately
- [ ] Disable Posturr via menu bar toggle → blur should clear immediately
- [ ] Re-enable Posturr → away detection should resume normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)