### PR TITLE
Implement automatic tracking mode with source resolution and fallback

### DIFF
--- a/Sources/AirPodsPostureDetector.swift
+++ b/Sources/AirPodsPostureDetector.swift
@@ -170,8 +170,11 @@ class AirPodsPostureDetector: NSObject, PostureDetector {
 
     // MARK: - Connection State (Protocol)
 
-    /// Whether AirPods are currently in ears and receiving motion data
-    var isConnected: Bool { isReceivingMotionData }
+    /// Whether compatible AirPods are paired (available for use)
+    var isConnected: Bool {
+        guard #available(macOS 14.0, *) else { return false }
+        return CMHeadphoneMotionManager().isDeviceMotionAvailable
+    }
 
     /// Callback when connection state changes (AirPods put in or removed from ears)
     var onConnectionStateChange: ((Bool) -> Void)? {
@@ -275,6 +278,31 @@ class AirPodsPostureDetector: NSObject, PostureDetector {
         isActive = false
         isReceivingMotionData = false
         isMonitoring = false
+    }
+
+    // MARK: - Connection Monitoring (for automatic mode fallback)
+
+    /// Start monitoring AirPods connection state without full motion tracking.
+    /// Used in automatic mode to detect when AirPods are put back in.
+    func startConnectionMonitoring() {
+        guard #available(macOS 14.0, *) else { return }
+
+        if motionManager == nil {
+            motionManager = CMHeadphoneMotionManager()
+        }
+        guard let manager = motionManager else { return }
+        manager.delegate = self
+        manager.startConnectionStatusUpdates()
+        os_log(.info, log: log, "Started AirPods connection monitoring (no motion)")
+    }
+
+    /// Stop connection-only monitoring.
+    func stopConnectionMonitoring() {
+        guard #available(macOS 14.0, *) else { return }
+        guard !isActive else { return } // Don't stop if full detector is running
+        motionManager?.stopConnectionStatusUpdates()
+        motionManager?.delegate = nil
+        os_log(.info, log: log, "Stopped AirPods connection monitoring")
     }
 
     // MARK: - Calibration

--- a/Sources/AppDelegate+Persistence.swift
+++ b/Sources/AppDelegate+Persistence.swift
@@ -25,6 +25,9 @@ extension AppDelegate {
             defaults.set(cameraID, forKey: SettingsKeys.lastCameraID)
         }
         defaults.set(trackingSource.rawValue, forKey: SettingsKeys.trackingSource)
+        defaults.set(trackingStore.withState { $0.trackingMode.rawValue }, forKey: SettingsKeys.trackingMode)
+        defaults.set(trackingStore.withState { $0.preferredSource.rawValue }, forKey: SettingsKeys.preferredSource)
+        defaults.set(trackingStore.withState { $0.autoReturnEnabled }, forKey: SettingsKeys.autoReturnEnabled)
         if let airPodsCalibration = airPodsCalibration,
            let data = try? JSONEncoder().encode(airPodsCalibration) {
             defaults.set(data, forKey: SettingsKeys.airPodsCalibration)
@@ -45,6 +48,17 @@ extension AppDelegate {
         if let sourceString = defaults.string(forKey: SettingsKeys.trackingSource),
            let source = TrackingSource(rawValue: sourceString) {
             trackingSource = source
+        }
+        if let modeString = defaults.string(forKey: SettingsKeys.trackingMode),
+           let mode = TrackingMode(rawValue: modeString) {
+            trackingStore.send(.setTrackingMode(mode))
+        }
+        if let prefString = defaults.string(forKey: SettingsKeys.preferredSource),
+           let pref = TrackingSource(rawValue: prefString) {
+            trackingStore.send(.setPreferredSource(pref))
+        }
+        if defaults.object(forKey: SettingsKeys.autoReturnEnabled) != nil {
+            trackingStore.send(.setAutoReturnEnabled(defaults.bool(forKey: SettingsKeys.autoReturnEnabled)))
         }
         if let data = defaults.data(forKey: SettingsKeys.airPodsCalibration),
            let calibration = try? JSONDecoder().decode(AirPodsCalibrationData.self, from: data) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -75,15 +75,35 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     var activeDetector: PostureDetector {
-        trackingSource == .camera ? cameraDetector : airPodsDetector
+        activeTrackingSource == .camera ? cameraDetector : airPodsDetector
+    }
+
+    var activeTrackingSource: TrackingSource {
+        trackingStore.withState { $0.activeSource }
+    }
+
+    var trackingMode: TrackingMode {
+        get { trackingStore.withState { $0.trackingMode } }
+        set {
+            let oldState = trackingStore.withState { $0 }
+            trackingStore.send(.setTrackingMode(newValue))
+            let newState = trackingStore.withState { $0 }
+            applyTrackingStoreTransition(from: oldState, to: newState)
+        }
     }
 
     // Calibration data storage
     var cameraCalibration: CameraCalibrationData?
     var airPodsCalibration: AirPodsCalibrationData?
+    /// Which source is currently being calibrated (nil when not calibrating)
+    var calibratingSource: TrackingSource?
+    /// Called when calibration completes successfully (for UI refresh)
+    var onCalibrationComplete: (() -> Void)?
+    /// Called when active source changes (for UI refresh)
+    var onActiveSourceChanged: (() -> Void)?
 
     var currentCalibration: CalibrationData? {
-        trackingSource == .camera ? cameraCalibration : airPodsCalibration
+        activeTrackingSource == .camera ? cameraCalibration : airPodsCalibration
     }
 
     // Legacy camera ID accessor for settings
@@ -177,6 +197,9 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
             }
             dependencies.trackingRuntime.retryCalibration = { [weak self] in
                 await self?.runtimeRetryCalibration()
+            }
+            dependencies.trackingRuntime.startCalibrationForSource = { [weak self] source in
+                await self?.runtimeStartCalibrationForSource(source)
             }
         }
     }()
@@ -490,6 +513,30 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         await trackingCoordinator.setPauseOnTheGoEnabled(isEnabled)
     }
 
+    func setTrackingMode(_ mode: TrackingMode) async {
+        trackingCoordinator.updateSourceReadiness()
+        let oldState = trackingStore.withState { $0 }
+        let storeTask = trackingStore.send(.setTrackingMode(mode))
+        await storeTask.finish()
+        let newState = trackingStore.withState { $0 }
+        applyTrackingStoreTransition(from: oldState, to: newState)
+        saveSettings()
+    }
+
+    func setPreferredSource(_ source: TrackingSource) async {
+        trackingCoordinator.updateSourceReadiness()
+        let oldState = trackingStore.withState { $0 }
+        let storeTask = trackingStore.send(.setPreferredSource(source))
+        await storeTask.finish()
+        let newState = trackingStore.withState { $0 }
+        applyTrackingStoreTransition(from: oldState, to: newState)
+        saveSettings()
+    }
+
+    func startCalibrationForSource(_ source: TrackingSource) {
+        trackingCoordinator.startCalibration(for: source)
+    }
+
     // MARK: - Calibration
 
     func startCalibration() {
@@ -519,7 +566,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func restartCamera() {
-        guard trackingSource == .camera, selectedCameraID != nil else { return }
+        guard activeTrackingSource == .camera, selectedCameraID != nil else { return }
 
         Task { @MainActor in
             await self.applyCameraSelectionTransition()
@@ -635,6 +682,10 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func runtimeRetryCalibration() async {
         await trackingCoordinator.runtimeRetryCalibration()
+    }
+
+    private func runtimeStartCalibrationForSource(_ source: TrackingSource) async {
+        await trackingCoordinator.runtimeStartCalibrationForSource(source)
     }
 
     private func showCalibrationPermissionDeniedAlert() async {
@@ -766,8 +817,14 @@ extension AppDelegate.TrackingCoordinator {
     ) {
         if applyStateTransition, oldTrackingState.appState != newTrackingState.appState {
             handleStateTransition(from: oldTrackingState.appState, to: newTrackingState.appState)
+        } else if oldTrackingState.activeSource != newTrackingState.activeSource {
+            syncDetectorToState()
+            syncUIToState()
         } else if oldTrackingState.manualSource != newTrackingState.manualSource {
             syncDetectorToState()
+        }
+        if oldTrackingState.activeSource != newTrackingState.activeSource {
+            appDelegate.onActiveSourceChanged?()
         }
     }
 
@@ -813,14 +870,27 @@ extension AppDelegate.TrackingCoordinator {
             return
         }
 
-        let shouldRun = PostureEngine.shouldDetectorRun(for: appDelegate.state, trackingSource: appDelegate.trackingSource)
+        let activeSource = appDelegate.activeTrackingSource
+        let shouldRun = PostureEngine.shouldDetectorRun(for: appDelegate.state, trackingSource: activeSource)
 
         // Always stop the other detector so in-flight starts are cancelled
         // even if that detector has not flipped isActive=true yet.
-        if appDelegate.trackingSource == .camera {
-            appDelegate.airPodsDetector.stop()
+        // But don't stop a detector that's currently being calibrated.
+        let calSource = appDelegate.calibratingSource
+        let isAutomatic = appDelegate.trackingMode == .automatic
+        if activeSource == .camera {
+            if calSource != .airpods {
+                appDelegate.airPodsDetector.stop()
+                // In automatic mode, keep AirPods connection monitoring alive
+                // so we can detect when they're put back in for auto-return.
+                if isAutomatic {
+                    appDelegate.airPodsDetector.startConnectionMonitoring()
+                }
+            }
         } else {
-            appDelegate.cameraDetector.stop()
+            if calSource != .camera { appDelegate.cameraDetector.stop() }
+            // Stop connection-only monitoring since AirPods detector is now active
+            appDelegate.airPodsDetector.stopConnectionMonitoring()
         }
 
         // Start/stop the active detector
@@ -853,12 +923,30 @@ extension AppDelegate.TrackingCoordinator {
             isCalibrated: appDelegate.isCalibrated,
             isCurrentlyAway: appDelegate.isCurrentlyAway,
             isCurrentlySlouching: appDelegate.isCurrentlySlouching,
-            trackingSource: appDelegate.trackingSource
+            trackingSource: appDelegate.activeTrackingSource,
+            isOnFallback: appDelegate.trackingStore.withState { $0.isOnFallback }
         )
 
         appDelegate.menuBarManager.updateStatus(text: uiState.statusText, icon: uiState.icon.menuBarIcon)
         appDelegate.menuBarManager.updateEnabledState(uiState.isEnabled)
         appDelegate.menuBarManager.updateRecalibrateEnabled(uiState.canRecalibrate)
+    }
+
+    func updateSourceReadiness() {
+        let cameraReadiness = TrackingSourceReadiness(
+            permissionGranted: true,
+            connected: !appDelegate.cameraDetector.getAvailableCameras().isEmpty,
+            calibrated: appDelegate.cameraCalibration?.isValid ?? false,
+            available: true
+        )
+        let airPodsReadiness = TrackingSourceReadiness(
+            permissionGranted: true,
+            connected: appDelegate.airPodsDetector.isConnected,
+            calibrated: appDelegate.airPodsCalibration?.isValid ?? false,
+            available: appDelegate.airPodsDetector.isAvailable
+        )
+        appDelegate.trackingStore.send(.sourceReadinessChanged(source: .camera, readiness: cameraReadiness))
+        appDelegate.trackingStore.send(.sourceReadinessChanged(source: .airpods, readiness: airPodsReadiness))
     }
 
     func setupDetectors() {
@@ -935,6 +1023,7 @@ extension AppDelegate.TrackingCoordinator {
         guard !appDelegate.setupComplete else { return }
         appDelegate.setupComplete = true
 
+        updateSourceReadiness()
         let context = appDelegate.makeInitialSetupContext()
         _ = await appDelegate.sendTrackingAction(
             .initialSetupEvaluated(
@@ -995,7 +1084,8 @@ extension AppDelegate.TrackingCoordinator {
         // Prevent multiple concurrent calibrations (use calibrationController as the lock)
         guard appDelegate.calibrationController == nil else { return }
 
-        os_log(.info, log: log, "Starting calibration for %{public}@", appDelegate.trackingSource.displayName)
+        appDelegate.calibratingSource = appDelegate.activeTrackingSource
+        os_log(.info, log: log, "Starting calibration for %{public}@", appDelegate.activeTrackingSource.displayName)
 
         // Request authorization (this shows permission dialog if needed)
         appDelegate.activeDetector.requestAuthorization { [weak self] authorized in
@@ -1003,7 +1093,8 @@ extension AppDelegate.TrackingCoordinator {
                 guard let self else { return }
 
                 if !authorized {
-                    os_log(.error, log: log, "Authorization denied for %{public}@", self.appDelegate.trackingSource.displayName)
+                    os_log(.error, log: log, "Authorization denied for %{public}@", self.appDelegate.activeTrackingSource.displayName)
+                    self.appDelegate.calibratingSource = nil
 
                     await self.appDelegate.sendTrackingAction(
                         .calibrationAuthorizationDenied(isCalibrated: self.appDelegate.isCalibrated)
@@ -1084,13 +1175,17 @@ extension AppDelegate.TrackingCoordinator {
             appDelegate.airPodsCalibration = airPodsCalibration
         }
 
+        let calibratedSource = appDelegate.calibratingSource ?? appDelegate.activeTrackingSource
+        appDelegate.calibratingSource = nil
         appDelegate.saveSettings()
         appDelegate.calibrationController = nil
 
-        await appDelegate.sendTrackingAction(.calibrationCompleted)
+        await appDelegate.sendTrackingAction(.calibrationCompleted(source: calibratedSource))
+        appDelegate.onCalibrationComplete?()
     }
 
     func cancelCalibration() async {
+        appDelegate.calibratingSource = nil
         appDelegate.calibrationController = nil
         await appDelegate.sendTrackingAction(.calibrationCancelled(isCalibrated: appDelegate.isCalibrated))
     }
@@ -1248,6 +1343,107 @@ extension AppDelegate.TrackingCoordinator {
         }
     }
 
+    func runtimeStartCalibrationForSource(_ source: TrackingSource) async {
+        appDelegate.trackingEffectIntentObserver?(.startCalibrationForSource(source))
+        startCalibration(for: source)
+    }
+
+    func startCalibration(for source: TrackingSource) {
+        guard appDelegate.calibrationController == nil else { return }
+
+        appDelegate.calibratingSource = source
+        os_log(.info, log: log, "Starting calibration for %{public}@", source.displayName)
+
+        let detector: PostureDetector = source == .camera ? appDelegate.cameraDetector : appDelegate.airPodsDetector
+        detector.requestAuthorization { [weak self] authorized in
+            Task { @MainActor in
+                guard let self else { return }
+                if !authorized {
+                    await self.appDelegate.sendTrackingAction(
+                        .calibrationAuthorizationDenied(isCalibrated: self.appDelegate.isCalibrated)
+                    )
+                    self.appDelegate.calibratingSource = nil
+                    return
+                }
+                await self.appDelegate.sendTrackingAction(.calibrationAuthorizationGranted)
+                self.startDetectorAndShowCalibration(for: source)
+            }
+        }
+    }
+
+    private func startDetectorAndShowCalibration(for source: TrackingSource) {
+        guard appDelegate.calibrationController == nil else { return }
+
+        let detector: PostureDetector = source == .camera ? appDelegate.cameraDetector : appDelegate.airPodsDetector
+        detector.start { [weak self] success, error in
+            Task { @MainActor in
+                guard let self else { return }
+                if !success {
+                    self.appDelegate.calibratingSource = nil
+                    await self.appDelegate.sendTrackingAction(.calibrationStartFailed(errorMessage: error))
+                    return
+                }
+                self.appDelegate.calibrationController = CalibrationWindowController()
+                self.appDelegate.calibrationController?.start(
+                    detector: detector,
+                    onComplete: { [weak self] values in
+                        Task { @MainActor in
+                            await self?.finishCalibrationForSource(values: values)
+                        }
+                    },
+                    onCancel: { [weak self] in
+                        Task { @MainActor in
+                            await self?.cancelCalibration()
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    func finishCalibrationForSource(values: [CalibrationSample]) async {
+        guard let source = appDelegate.calibratingSource else {
+            await finishCalibration(values: values)
+            return
+        }
+
+        guard values.count >= 4 else {
+            await cancelCalibration()
+            return
+        }
+
+        os_log(.info, log: log, "Finishing calibration for %{public}@ with %d values", source.displayName, values.count)
+
+        let detector: PostureDetector = source == .camera ? appDelegate.cameraDetector : appDelegate.airPodsDetector
+        guard let calibration = detector.createCalibrationData(from: values) else {
+            await cancelCalibration()
+            return
+        }
+
+        if let cameraCalibration = calibration as? CameraCalibrationData {
+            appDelegate.cameraCalibration = cameraCalibration
+            let profile = ProfileData(
+                goodPostureY: cameraCalibration.goodPostureY,
+                badPostureY: cameraCalibration.badPostureY,
+                neutralY: cameraCalibration.neutralY,
+                postureRange: cameraCalibration.postureRange,
+                cameraID: cameraCalibration.cameraID
+            )
+            let configKey = DisplayMonitor.getCurrentConfigKey()
+            appDelegate.saveProfile(forKey: configKey, data: profile)
+        } else if let airPodsCalibration = calibration as? AirPodsCalibrationData {
+            appDelegate.airPodsCalibration = airPodsCalibration
+        }
+
+        let calibratedSource = source
+        appDelegate.calibratingSource = nil
+        appDelegate.saveSettings()
+        appDelegate.calibrationController = nil
+
+        await appDelegate.sendTrackingAction(.calibrationCompleted(source: calibratedSource))
+        appDelegate.onCalibrationComplete?()
+    }
+
     func showCalibrationPermissionDeniedAlert() async {
         if let calibrationPermissionDeniedAlertDecision = appDelegate.calibrationPermissionDeniedAlertDecision {
             if calibrationPermissionDeniedAlertDecision(appDelegate.trackingSource) {
@@ -1256,10 +1452,11 @@ extension AppDelegate.TrackingCoordinator {
             return
         }
 
+        let source = appDelegate.calibratingSource ?? appDelegate.activeTrackingSource
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = L("alert.permissionRequired")
-        alert.informativeText = appDelegate.trackingSource == .airpods
+        alert.informativeText = source == .airpods
             ? L("alert.permissionRequired.airpods")
             : L("alert.permissionRequired.camera")
         alert.addButton(withTitle: L("alert.openSettings"))
@@ -1276,7 +1473,9 @@ extension AppDelegate.TrackingCoordinator {
             return
         }
 
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy") else { return }
+        let source = appDelegate.calibratingSource ?? appDelegate.activeTrackingSource
+        let pane = source == .airpods ? "Privacy_Motion" : "Privacy_Camera"
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?\(pane)") else { return }
         NSWorkspace.shared.open(url)
     }
 
@@ -1408,7 +1607,9 @@ extension AppDelegate.TrackingCoordinator {
     }
 
     func handleCameraConnected(_ device: AVCaptureDevice) async {
-        guard appDelegate.trackingSource == .camera else { return }
+        guard appDelegate.activeTrackingSource == .camera
+              || appDelegate.trackingStore.withState({ $0.trackingMode }) == .automatic
+        else { return }
         let context = makeCameraConnectedContext(for: device)
 
         await applyCameraConnectedTransition(
@@ -1418,7 +1619,9 @@ extension AppDelegate.TrackingCoordinator {
     }
 
     func handleCameraDisconnected(_ device: AVCaptureDevice) async {
-        guard appDelegate.trackingSource == .camera else { return }
+        guard appDelegate.activeTrackingSource == .camera
+              || appDelegate.trackingStore.withState({ $0.trackingMode }) == .automatic
+        else { return }
         let context = makeCameraDisconnectContext(for: device)
 
         await applyCameraDisconnectedTransition(

--- a/Sources/MenuBar.swift
+++ b/Sources/MenuBar.swift
@@ -69,16 +69,21 @@ final class MenuBarManager {
 
     // MARK: - Updates
 
+    private var isSetUp: Bool { statusItem != nil }
+
     func updateStatus(text: String, icon: MenuBarIcon) {
+        guard isSetUp else { return }
         statusMenuItem.title = text
         statusItem.button?.image = icon.image
     }
 
     func updateEnabledState(_ enabled: Bool) {
+        guard isSetUp else { return }
         enabledMenuItem.state = enabled ? .on : .off
     }
 
     func updateRecalibrateEnabled(_ enabled: Bool) {
+        guard isSetUp else { return }
         recalibrateMenuItem.isEnabled = enabled
     }
 

--- a/Sources/OnboardingWindow.swift
+++ b/Sources/OnboardingWindow.swift
@@ -34,10 +34,10 @@ class OnboardingWindowController: NSObject, NSWindowDelegate {
         )
 
         let hostingController = NSHostingController(rootView: onboardingView)
-        let fittingSize = hostingController.sizeThatFits(in: CGSize(width: 500, height: 600))
+        hostingController.sizingOptions = .preferredContentSize
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: fittingSize.width, height: fittingSize.height),
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 100),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/Sources/PostureDetector.swift
+++ b/Sources/PostureDetector.swift
@@ -112,6 +112,13 @@ enum TrackingSource: String, Codable, CaseIterable, Identifiable {
             return L("trackingSource.airpods.requirement")
         }
     }
+
+    var other: TrackingSource {
+        switch self {
+        case .camera: return .airpods
+        case .airpods: return .camera
+        }
+    }
 }
 
 // MARK: - Posture Detector Protocol

--- a/Sources/PostureEngine.swift
+++ b/Sources/PostureEngine.swift
@@ -112,8 +112,68 @@ struct InitialSetupTransitionResult: Equatable {
     let shouldShowOnboarding: Bool
 }
 
+/// Result of automatic source resolution
+struct SourceResolutionResult: Equatable {
+    /// The source to activate, or nil to keep current
+    let activeSource: TrackingSource?
+    let newState: AppState
+    let shouldStartMonitoring: Bool
+}
+
 /// Pure logic engine for posture monitoring - no side effects
 struct PostureEngine {
+
+    // MARK: - Automatic Source Resolution
+
+    /// Resolves which source should be active in automatic mode.
+    /// "Ready" means calibrated AND connected.
+    static func resolveActiveSource(
+        preferred: TrackingSource,
+        currentActive: TrackingSource,
+        currentState: AppState,
+        preferredReadiness: TrackingSourceReadiness,
+        fallbackReadiness: TrackingSourceReadiness,
+        autoReturn: Bool
+    ) -> SourceResolutionResult {
+        let preferredReady = preferredReadiness.calibrated && preferredReadiness.connected
+        let fallbackReady = fallbackReadiness.calibrated && fallbackReadiness.connected
+
+        // Preferred is ready — use it
+        if preferredReady {
+            let shouldStart = currentActive != preferred || !currentState.isActive
+            return SourceResolutionResult(
+                activeSource: preferred,
+                newState: .monitoring,
+                shouldStartMonitoring: shouldStart
+            )
+        }
+
+        // Preferred not ready, fallback is ready — use fallback
+        if fallbackReady {
+            let shouldStart = currentActive != preferred.other || !currentState.isActive
+            return SourceResolutionResult(
+                activeSource: preferred.other,
+                newState: .monitoring,
+                shouldStartMonitoring: shouldStart
+            )
+        }
+
+        // Preferred connected but not calibrated, fallback not ready
+        if preferredReadiness.connected && !preferredReadiness.calibrated {
+            return SourceResolutionResult(
+                activeSource: nil,
+                newState: .paused(.noProfile),
+                shouldStartMonitoring: false
+            )
+        }
+
+        // Neither ready — pause with preferred's unavail reason
+        return SourceResolutionResult(
+            activeSource: nil,
+            newState: unavailableState(for: preferred),
+            shouldStartMonitoring: false
+        )
+    }
 
     // MARK: - Posture Reading Processing
 

--- a/Sources/PostureUIState.swift
+++ b/Sources/PostureUIState.swift
@@ -22,7 +22,8 @@ struct PostureUIState: Equatable {
         isCalibrated: Bool,
         isCurrentlyAway: Bool,
         isCurrentlySlouching: Bool,
-        trackingSource: TrackingSource
+        trackingSource: TrackingSource,
+        isOnFallback: Bool = false
     ) -> PostureUIState {
         switch appState {
         case .disabled:
@@ -45,7 +46,9 @@ struct PostureUIState: Equatable {
             let (statusText, icon) = monitoringState(
                 isCalibrated: isCalibrated,
                 isCurrentlyAway: isCurrentlyAway,
-                isCurrentlySlouching: isCurrentlySlouching
+                isCurrentlySlouching: isCurrentlySlouching,
+                isOnFallback: isOnFallback,
+                fallbackSource: trackingSource
             )
             return PostureUIState(
                 statusText: statusText,
@@ -68,18 +71,22 @@ struct PostureUIState: Equatable {
     private static func monitoringState(
         isCalibrated: Bool,
         isCurrentlyAway: Bool,
-        isCurrentlySlouching: Bool
+        isCurrentlySlouching: Bool,
+        isOnFallback: Bool = false,
+        fallbackSource: TrackingSource = .camera
     ) -> (String, MenuBarIconType) {
         guard isCalibrated else {
             return (L("status.starting"), .good)
         }
 
+        let suffix = isOnFallback ? " (\(fallbackSource.displayName))" : ""
+
         if isCurrentlyAway {
-            return (L("status.away"), .away)
+            return (L("status.away") + suffix, .away)
         } else if isCurrentlySlouching {
-            return (L("status.slouching"), .bad)
+            return (L("status.slouching") + suffix, .bad)
         } else {
-            return (L("status.goodPosture"), .good)
+            return (L("status.goodPosture") + suffix, .good)
         }
     }
 

--- a/Sources/Resources/de.lproj/Localizable.strings
+++ b/Sources/Resources/de.lproj/Localizable.strings
@@ -108,10 +108,19 @@
 
 "settings.title" = "Einstellungen";
 "settings.tracking" = "Tracking";
+"settings.tracking.help" = "Manuell nutzt eine Quelle. Automatisch wechselt zwischen Kamera und AirPods je nach Verfügbarkeit und bevorzugt Ihre gewählte Quelle.";
 "settings.noCameras" = "Keine Kameras";
 "settings.connected" = "Verbunden";
 "settings.notConnected" = "Nicht verbunden";
 "settings.recalibrate" = "Neu kalibrieren";
+"settings.mode.manual" = "Manuell";
+"settings.mode.automatic" = "Automatisch";
+"settings.preferred" = "Bevorzugt";
+"settings.active" = "Aktiv";
+"settings.calibrated" = "Kalibriert";
+"settings.notCalibrated" = "Nicht kalibriert";
+"settings.preferredNeedsCalibration" = "Bevorzugtes Gerät muss kalibriert werden";
+"settings.calibratePreferred" = "Kalibrieren";
 "settings.profile" = "Profil";
 "settings.profile.help" = "Speichern Sie verschiedene Konfigurationen für verschiedene Situationen. Wechseln Sie das Profil, um alle Einstellungen sofort anzuwenden.";
 "settings.profile.new" = "Neu";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -108,10 +108,19 @@
 
 "settings.title" = "Settings";
 "settings.tracking" = "Tracking";
+"settings.tracking.help" = "Manual uses one source. Automatic switches between Camera and AirPods based on availability, using your preferred source when possible.";
 "settings.noCameras" = "No cameras";
 "settings.connected" = "Connected";
 "settings.notConnected" = "Not connected";
 "settings.recalibrate" = "Recalibrate";
+"settings.mode.manual" = "Manual";
+"settings.mode.automatic" = "Automatic";
+"settings.preferred" = "Preferred";
+"settings.active" = "Active";
+"settings.calibrated" = "Calibrated";
+"settings.notCalibrated" = "Not calibrated";
+"settings.preferredNeedsCalibration" = "Preferred device needs calibration";
+"settings.calibratePreferred" = "Calibrate";
 "settings.profile" = "Profile";
 "settings.profile.help" = "Save different configurations for different situations. Switch profiles to instantly apply all settings below.";
 "settings.profile.new" = "New";

--- a/Sources/Resources/es.lproj/Localizable.strings
+++ b/Sources/Resources/es.lproj/Localizable.strings
@@ -108,10 +108,19 @@
 
 "settings.title" = "Ajustes";
 "settings.tracking" = "Seguimiento";
+"settings.tracking.help" = "Manual usa una fuente. Automático cambia entre Cámara y AirPods según disponibilidad, usando tu fuente preferida cuando sea posible.";
 "settings.noCameras" = "Sin cámaras";
 "settings.connected" = "Conectado";
 "settings.notConnected" = "No conectado";
 "settings.recalibrate" = "Recalibrar";
+"settings.mode.manual" = "Manual";
+"settings.mode.automatic" = "Automático";
+"settings.preferred" = "Preferido";
+"settings.active" = "Activo";
+"settings.calibrated" = "Calibrado";
+"settings.notCalibrated" = "Sin calibrar";
+"settings.preferredNeedsCalibration" = "El dispositivo preferido necesita calibración";
+"settings.calibratePreferred" = "Calibrar";
 "settings.profile" = "Perfil";
 "settings.profile.help" = "Guarda diferentes configuraciones para diferentes situaciones. Cambia de perfil para aplicar instantáneamente todos los ajustes.";
 "settings.profile.new" = "Nuevo";

--- a/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Resources/fr.lproj/Localizable.strings
@@ -108,10 +108,19 @@
 
 "settings.title" = "Réglages";
 "settings.tracking" = "Suivi";
+"settings.tracking.help" = "Manuel utilise une seule source. Automatique bascule entre Caméra et AirPods selon la disponibilité, en privilégiant votre source préférée.";
 "settings.noCameras" = "Aucune caméra";
 "settings.connected" = "Connecté";
 "settings.notConnected" = "Non connecté";
 "settings.recalibrate" = "Recalibrer";
+"settings.mode.manual" = "Manuel";
+"settings.mode.automatic" = "Automatique";
+"settings.preferred" = "Préféré";
+"settings.active" = "Actif";
+"settings.calibrated" = "Calibré";
+"settings.notCalibrated" = "Non calibré";
+"settings.preferredNeedsCalibration" = "L'appareil préféré doit être calibré";
+"settings.calibratePreferred" = "Calibrer";
 "settings.profile" = "Profil";
 "settings.profile.help" = "Enregistrez différentes configurations pour différentes situations. Changez de profil pour appliquer instantanément tous les réglages.";
 "settings.profile.new" = "Nouveau";

--- a/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Resources/ja.lproj/Localizable.strings
@@ -108,10 +108,19 @@
 
 "settings.title" = "設定";
 "settings.tracking" = "トラッキング";
+"settings.tracking.help" = "手動は1つのソースを使用します。自動はカメラとAirPodsの間で切り替え、優先ソースを可能な限り使用します。";
 "settings.noCameras" = "カメラなし";
 "settings.connected" = "接続済み";
 "settings.notConnected" = "未接続";
 "settings.recalibrate" = "再キャリブレーション";
+"settings.mode.manual" = "手動";
+"settings.mode.automatic" = "自動";
+"settings.preferred" = "優先";
+"settings.active" = "使用中";
+"settings.calibrated" = "校正済み";
+"settings.notCalibrated" = "未校正";
+"settings.preferredNeedsCalibration" = "優先デバイスの校正が必要です";
+"settings.calibratePreferred" = "校正する";
 "settings.profile" = "プロファイル";
 "settings.profile.help" = "異なる状況に合わせた設定を保存できます。プロファイルを切り替えて、すべての設定を即座に適用できます。";
 "settings.profile.new" = "新規";

--- a/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -108,10 +108,19 @@
 
 "settings.title" = "设置";
 "settings.tracking" = "追踪";
+"settings.tracking.help" = "手动使用单一来源。自动根据可用性在摄像头和AirPods之间切换，优先使用您选择的来源。";
 "settings.noCameras" = "无摄像头";
 "settings.connected" = "已连接";
 "settings.notConnected" = "未连接";
 "settings.recalibrate" = "重新校准";
+"settings.mode.manual" = "手动";
+"settings.mode.automatic" = "自动";
+"settings.preferred" = "首选";
+"settings.active" = "活跃";
+"settings.calibrated" = "已校准";
+"settings.notCalibrated" = "未校准";
+"settings.preferredNeedsCalibration" = "首选设备需要校准";
+"settings.calibratePreferred" = "校准";
 "settings.profile" = "配置文件";
 "settings.profile.help" = "为不同场景保存不同的配置。切换配置文件即可立即应用所有设置。";
 "settings.profile.new" = "新建";

--- a/Sources/SettingsKeys.swift
+++ b/Sources/SettingsKeys.swift
@@ -21,6 +21,9 @@ enum SettingsKeys {
     static let toggleShortcutModifiers = "toggleShortcutModifiers"
     static let detectionMode = "detectionMode"
     static let trackingSource = "trackingSource"
+    static let trackingMode = "trackingMode"
+    static let preferredSource = "preferredSource"
+    static let autoReturnEnabled = "autoReturnEnabled"
     static let airPodsCalibration = "airPodsCalibration"
 
     // Legacy keys (migrated on load)

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -349,6 +349,118 @@ struct BrightnessSliderView: View {
     }
 }
 
+// MARK: - Compact Mode Picker
+
+struct CompactModePicker: View {
+    @Binding var selection: TrackingMode
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach([TrackingMode.manual, .automatic], id: \.self) { mode in
+                Button(action: { selection = mode }) {
+                    Text(mode == .manual ? L("settings.mode.manual") : L("settings.mode.automatic"))
+                        .font(.system(size: 10, weight: selection == mode ? .semibold : .regular))
+                        .foregroundColor(selection == mode ? .onBrandCyan : .primary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 5)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                .fill(selection == mode ? Color.brandCyan : Color.clear)
+                        )
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.06))
+        )
+    }
+}
+
+// MARK: - Device Status Row
+
+struct DeviceStatusRow: View {
+    let source: TrackingSource
+    let isCalibrated: Bool
+    let isConnected: Bool
+    let isPreferred: Bool
+    var isActive: Bool = false
+    var cameraDropdown: AnyView? = nil
+    let onCalibrate: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            // Device icon and name
+            Image(systemName: source.icon)
+                .font(.system(size: 10))
+                .foregroundColor(isPreferred ? .brandCyan : .secondary)
+                .frame(width: 14)
+
+            Text(source.displayName)
+                .font(.system(size: 11, weight: isPreferred ? .medium : .regular))
+                .frame(width: 55, alignment: .leading)
+
+            // Calibration status
+            HStack(spacing: 3) {
+                Image(systemName: isCalibrated ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                    .font(.system(size: 9))
+                    .foregroundColor(isCalibrated ? .green : .orange)
+                Text(isCalibrated ? L("settings.calibrated") : L("settings.notCalibrated"))
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+
+            if source == .camera, let dropdown = cameraDropdown {
+                dropdown
+            } else if source == .airpods {
+                // Connection status
+                HStack(spacing: 3) {
+                    Circle()
+                        .fill(isConnected ? Color.green : Color.secondary.opacity(0.3))
+                        .frame(width: 6, height: 6)
+                    Text(isConnected ? L("settings.connected") : L("settings.notConnected"))
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if isActive {
+                Text(L("settings.active"))
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(.brandCyan)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(Color.brandCyan.opacity(0.12)))
+            }
+
+            // Calibrate button
+            Button(action: onCalibrate) {
+                Text(L("settings.recalibrate"))
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(.onBrandCyan)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .fill(Color.brandCyan)
+                    )
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.03))
+        )
+    }
+}
+
 // MARK: - Compact Tracking Source Picker
 
 struct CompactTrackingSourcePicker: View {
@@ -439,7 +551,12 @@ struct SettingsView: View {
     @State private var toggleShortcut: KeyboardShortcut
     @State private var detectionModeSlider: Double
     @State private var trackingSource: TrackingSource
+    @State private var trackingModeSelection: TrackingMode
+    @State private var preferredSource: TrackingSource
     @State private var airPodsAvailable: Bool
+    @State private var cameraCalibrated: Bool
+    @State private var airPodsCalibrated: Bool
+    @State private var activeSource: TrackingSource
     @State private var settingsProfiles: [SettingsProfile]
     @State private var selectedSettingsProfileID: String
     @State private var lastSelectedSettingsProfileID: String
@@ -497,7 +614,12 @@ struct SettingsView: View {
         _toggleShortcut = State(initialValue: appDelegate.toggleShortcut)
         _detectionModeSlider = State(initialValue: Double(detectionModes.firstIndex(of: profileDetectionMode) ?? 0))
         _trackingSource = State(initialValue: appDelegate.trackingSource)
+        _trackingModeSelection = State(initialValue: appDelegate.trackingStore.withState { $0.trackingMode })
+        _preferredSource = State(initialValue: appDelegate.trackingStore.withState { $0.preferredSource })
         _airPodsAvailable = State(initialValue: appDelegate.airPodsDetector.isAvailable)
+        _cameraCalibrated = State(initialValue: appDelegate.cameraCalibration?.isValid ?? false)
+        _airPodsCalibrated = State(initialValue: appDelegate.airPodsCalibration?.isValid ?? false)
+        _activeSource = State(initialValue: appDelegate.activeTrackingSource)
         settingsProfileManager.ensureProfilesLoaded()
         let snapshot = settingsProfileManager.profilesState()
         let profiles = snapshot.profiles
@@ -561,78 +683,165 @@ struct SettingsView: View {
 
             SubtleDivider()
 
-            // Tracking row (not part of profile)
-            HStack(spacing: 8) {
-                Text(L("settings.tracking"))
-                    .font(.system(size: 11, weight: .medium))
-                    .frame(width: 82, alignment: .leading)
+            // Tracking section (not part of profile)
+            VStack(spacing: 6) {
+                // Mode row
+                HStack(spacing: 8) {
+                    Text(L("settings.tracking"))
+                        .font(.system(size: 11, weight: .medium))
+                        .frame(width: 82, alignment: .leading)
 
-                CompactTrackingSourcePicker(
-                    selection: $trackingSource,
-                    airPodsAvailable: airPodsAvailable
-                )
-                .frame(width: 130)
-                .onChange(of: trackingSource) { newValue in
-                    if newValue != appDelegate.trackingSource {
-                        Task { @MainActor in
-                            await appDelegate.switchTrackingSource(to: newValue)
-                        }
-                    }
-                }
+                    CompactModePicker(selection: $trackingModeSelection)
+                        .frame(width: 150)
 
-                if trackingSource == .camera {
-                    if availableCameras.isEmpty {
-                        Text(L("settings.noCameras"))
-                            .font(.system(size: 10))
-                            .foregroundColor(.secondary)
-                    } else {
-                        Picker("", selection: $selectedCameraID) {
-                            ForEach(availableCameras, id: \.id) { camera in
-                                Text(camera.name).tag(camera.id)
+                    HelpButton(text: L("settings.tracking.help"))
+                        .onChange(of: trackingModeSelection) { newValue in
+                            Task { @MainActor in
+                                await appDelegate.setTrackingMode(newValue)
+                                activeSource = appDelegate.activeTrackingSource
                             }
                         }
-                        .labelsHidden()
-                        .frame(maxWidth: .infinity)
-                        .onChange(of: selectedCameraID) { newValue in
-                            if newValue != appDelegate.selectedCameraID {
-                                appDelegate.selectedCameraID = newValue
-                                appDelegate.saveSettings()
-                                appDelegate.restartCamera()
-                            }
-                        }
-                    }
-                } else {
-                    // AirPods status
-                    HStack(spacing: 4) {
-                        Image(systemName: airPodsAvailable ? "checkmark.circle.fill" : "exclamationmark.circle")
-                            .foregroundColor(airPodsAvailable ? .green : .secondary)
-                            .font(.system(size: 10))
-                        Text(airPodsAvailable ? L("settings.connected") : L("settings.notConnected"))
-                            .font(.system(size: 10))
-                            .foregroundColor(.secondary)
-                    }
+
                     Spacer()
                 }
+                .frame(height: 26)
 
-                // Recalibrate button
-                Button(action: { appDelegate.startCalibration() }) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "arrow.triangle.2.circlepath")
-                            .font(.system(size: 10, weight: .semibold))
-                        Text(L("settings.recalibrate"))
-                            .font(.system(size: 11, weight: .medium))
+                if trackingModeSelection == .manual {
+                    // Manual mode: source picker + device row for selected source
+                    HStack(spacing: 8) {
+                        Text("")
+                            .frame(width: 82)
+
+                        CompactTrackingSourcePicker(
+                            selection: $trackingSource,
+                            airPodsAvailable: airPodsAvailable
+                        )
+                        .frame(width: 150)
+                        .onChange(of: trackingSource) { newValue in
+                            if newValue != appDelegate.trackingSource {
+                                Task { @MainActor in
+                                    await appDelegate.switchTrackingSource(to: newValue)
+                                }
+                            }
+                        }
+
+                        Spacer()
                     }
-                    .foregroundColor(.onBrandCyan)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .fill(Color.brandCyan)
+                    .frame(height: 26)
+
+                    DeviceStatusRow(
+                        source: trackingSource,
+                        isCalibrated: trackingSource == .camera ? cameraCalibrated : airPodsCalibrated,
+                        isConnected: trackingSource == .camera ? !availableCameras.isEmpty : airPodsAvailable,
+                        isPreferred: false,
+                        isActive: appDelegate.state.isActive,
+                        cameraDropdown: trackingSource == .camera && !availableCameras.isEmpty ? AnyView(
+                            Picker("", selection: $selectedCameraID) {
+                                ForEach(availableCameras, id: \.id) { camera in
+                                    Text(camera.name).tag(camera.id)
+                                }
+                            }
+                            .labelsHidden()
+                            .frame(maxWidth: 140)
+                            .onChange(of: selectedCameraID) { newValue in
+                                if newValue != appDelegate.selectedCameraID {
+                                    appDelegate.selectedCameraID = newValue
+                                    appDelegate.saveSettings()
+                                    appDelegate.restartCamera()
+                                }
+                            }
+                        ) : nil,
+                        onCalibrate: {
+                            appDelegate.startCalibration()
+                        }
                     )
+                } else {
+                    // Automatic mode layout
+                    VStack(spacing: 6) {
+                        // Preferred source picker
+                        HStack(spacing: 8) {
+                            Text(L("settings.preferred"))
+                                .font(.system(size: 11, weight: .medium))
+                                .frame(width: 82, alignment: .leading)
+
+                            CompactTrackingSourcePicker(
+                                selection: $preferredSource,
+                                airPodsAvailable: true
+                            )
+                            .frame(width: 150)
+                            .onChange(of: preferredSource) { newValue in
+                                Task { @MainActor in
+                                    await appDelegate.setPreferredSource(newValue)
+                                    activeSource = appDelegate.activeTrackingSource
+                                }
+                            }
+
+                            Spacer()
+                        }
+                        .frame(height: 26)
+
+                        // Device status rows
+                        DeviceStatusRow(
+                            source: .camera,
+                            isCalibrated: cameraCalibrated,
+                            isConnected: !availableCameras.isEmpty,
+                            isPreferred: preferredSource == .camera,
+                            isActive: activeSource == .camera && appDelegate.state.isActive,
+                            cameraDropdown: availableCameras.isEmpty ? nil : AnyView(
+                                Picker("", selection: $selectedCameraID) {
+                                    ForEach(availableCameras, id: \.id) { camera in
+                                        Text(camera.name).tag(camera.id)
+                                    }
+                                }
+                                .labelsHidden()
+                                .frame(maxWidth: 140)
+                                .onChange(of: selectedCameraID) { newValue in
+                                    if newValue != appDelegate.selectedCameraID {
+                                        appDelegate.selectedCameraID = newValue
+                                        appDelegate.saveSettings()
+                                        appDelegate.restartCamera()
+                                    }
+                                }
+                            ),
+                            onCalibrate: {
+                                appDelegate.startCalibrationForSource(.camera)
+                            }
+                        )
+
+                        DeviceStatusRow(
+                            source: .airpods,
+                            isCalibrated: airPodsCalibrated,
+                            isConnected: airPodsAvailable,
+                            isPreferred: preferredSource == .airpods,
+                            isActive: activeSource == .airpods && appDelegate.state.isActive,
+                            onCalibrate: {
+                                appDelegate.startCalibrationForSource(.airpods)
+                            }
+                        )
+
+                        // Warning banner when preferred device not calibrated
+                        if (preferredSource == .camera && !cameraCalibrated)
+                            || (preferredSource == .airpods && !airPodsCalibrated)
+                        {
+                            HStack(spacing: 6) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .font(.system(size: 10))
+                                    .foregroundColor(.orange)
+                                Text(L("settings.preferredNeedsCalibration"))
+                                    .font(.system(size: 10))
+                                    .foregroundColor(.secondary)
+                                Spacer()
+                            }
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 6)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .fill(Color.orange.opacity(0.08))
+                            )
+                        }
+                    }
                 }
-                .buttonStyle(.plain)
             }
-            .frame(height: 26)
             .padding(.vertical, 10)
 
             // Profile Section Card
@@ -938,6 +1147,18 @@ struct SettingsView: View {
         } message: {
             Text(L("settings.profile.deleteMessage"))
         }
+        .onAppear {
+            appDelegate.onCalibrationComplete = {
+                cameraCalibrated = appDelegate.cameraCalibration?.isValid ?? false
+                airPodsCalibrated = appDelegate.airPodsCalibration?.isValid ?? false
+                activeSource = appDelegate.activeTrackingSource
+            }
+            appDelegate.onActiveSourceChanged = {
+                activeSource = appDelegate.activeTrackingSource
+            }
+        }
+        // Cleanup happens in SettingsWindowController.windowWillClose
+        // (not onDisappear, which fires when calibration window covers this view)
     }
 
     private func syncProfileSettings() {

--- a/Sources/SettingsWindowController.swift
+++ b/Sources/SettingsWindowController.swift
@@ -56,6 +56,8 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         if let appDelegate = appDelegate, !appDelegate.showInDock {
             NSApp.setActivationPolicy(.accessory)
         }
+        appDelegate?.onCalibrationComplete = nil
+        appDelegate?.onActiveSourceChanged = nil
     }
 
     private func isWindowOnScreen(_ window: NSWindow) -> Bool {

--- a/Sources/TrackingFeature.swift
+++ b/Sources/TrackingFeature.swift
@@ -37,23 +37,68 @@ struct TrackingFeature: Reducer {
         case openPrivacySettings
         case showCameraCalibrationRetryAlert(message: String?)
         case retryCalibration
+        case startCalibrationForSource(TrackingSource)
     }
 
     struct State: Equatable {
         var appState: AppState = .disabled
 
-        // Manual mode remains the runtime policy during migration.
         var trackingMode: TrackingMode = .manual
         var manualSource: TrackingSource = .camera
         var preferredSource: TrackingSource = .camera
-        var autoReturnEnabled: Bool = false
+        var autoReturnEnabled: Bool = true
+        var activeSource: TrackingSource = .camera
+
+        var cameraReadiness = TrackingSourceReadiness()
+        var airPodsReadiness = TrackingSourceReadiness()
 
         var stateBeforeLock: AppState?
         var monitoringState = PostureMonitoringState()
         var postureConfig = PostureConfig()
         var lastPostureReadingTime: Date?
 
-        var activeSource: TrackingSource { manualSource }
+        init(
+            appState: AppState = .disabled,
+            trackingMode: TrackingMode = .manual,
+            manualSource: TrackingSource = .camera,
+            preferredSource: TrackingSource = .camera,
+            autoReturnEnabled: Bool = true,
+            activeSource: TrackingSource? = nil,
+            cameraReadiness: TrackingSourceReadiness = TrackingSourceReadiness(),
+            airPodsReadiness: TrackingSourceReadiness = TrackingSourceReadiness(),
+            stateBeforeLock: AppState? = nil,
+            monitoringState: PostureMonitoringState = PostureMonitoringState(),
+            postureConfig: PostureConfig = PostureConfig(),
+            lastPostureReadingTime: Date? = nil
+        ) {
+            self.appState = appState
+            self.trackingMode = trackingMode
+            self.manualSource = manualSource
+            self.preferredSource = preferredSource
+            self.autoReturnEnabled = autoReturnEnabled
+            self.activeSource = activeSource ?? manualSource
+            self.cameraReadiness = cameraReadiness
+            self.airPodsReadiness = airPodsReadiness
+            self.stateBeforeLock = stateBeforeLock
+            self.monitoringState = monitoringState
+            self.postureConfig = postureConfig
+            self.lastPostureReadingTime = lastPostureReadingTime
+        }
+
+        func readiness(for source: TrackingSource) -> TrackingSourceReadiness {
+            switch source {
+            case .camera: return cameraReadiness
+            case .airpods: return airPodsReadiness
+            }
+        }
+
+        var fallbackSource: TrackingSource {
+            preferredSource == .camera ? .airpods : .camera
+        }
+
+        var isOnFallback: Bool {
+            trackingMode == .automatic && activeSource != preferredSource
+        }
     }
 
     enum Action: Equatable {
@@ -101,7 +146,7 @@ struct TrackingFeature: Reducer {
         case calibrationStartFailed(errorMessage: String?)
         case runtimeDetectorStartFailed(trackingSource: TrackingSource)
         case calibrationCancelled(isCalibrated: Bool)
-        case calibrationCompleted
+        case calibrationCompleted(source: TrackingSource)
         case screenLocked
         case screenUnlocked
         case displayConfigurationChanged(
@@ -114,6 +159,7 @@ struct TrackingFeature: Reducer {
         )
         case cameraSelectionChanged
         case switchTrackingSource(TrackingSource, isNewSourceCalibrated: Bool)
+        case sourceReadinessChanged(source: TrackingSource, readiness: TrackingSourceReadiness)
     }
 
     @Dependency(\.trackingRuntime) var trackingRuntime
@@ -148,6 +194,7 @@ struct TrackingFeature: Reducer {
 
             case let .toggleEnabled(trackingSource, isCalibrated, detectorAvailable):
                 state.manualSource = trackingSource
+                state.activeSource = trackingSource
                 if state.appState == .disabled {
                     state.appState = PostureEngine.stateWhenEnabling(
                         isCalibrated: isCalibrated,
@@ -166,14 +213,36 @@ struct TrackingFeature: Reducer {
 
             case .setTrackingMode(let mode):
                 state.trackingMode = mode
+                if mode == .automatic {
+                    return finish(resolveAutomaticSource(&state))
+                }
+                // Switching back to manual: activeSource follows manualSource
+                let previousSource = state.activeSource
+                state.activeSource = state.manualSource
+                let sourceChanged = state.activeSource != previousSource
+                if sourceChanged && state.appState == .monitoring {
+                    return finish(run { runtime in
+                        await runtime.beginMonitoringSession()
+                    })
+                }
                 return finish()
 
             case .setManualSource(let source):
+                let previousSource = state.activeSource
                 state.manualSource = source
+                state.activeSource = source
+                if state.activeSource != previousSource && state.appState == .monitoring {
+                    return finish(run { runtime in
+                        await runtime.beginMonitoringSession()
+                    })
+                }
                 return finish()
 
             case .setPreferredSource(let source):
                 state.preferredSource = source
+                if state.trackingMode == .automatic {
+                    return finish(resolveAutomaticSource(&state))
+                }
                 return finish()
 
             case .setAutoReturnEnabled(let enabled):
@@ -288,6 +357,7 @@ struct TrackingFeature: Reducer {
 
             case let .startMonitoringRequested(isMarketingMode, trackingSource, isCalibrated, isConnected):
                 state.manualSource = trackingSource
+                state.activeSource = trackingSource
                 state.lastPostureReadingTime = nil
                 let result = PostureEngine.stateWhenMonitoringStarts(
                     isMarketingMode: isMarketingMode,
@@ -304,6 +374,10 @@ struct TrackingFeature: Reducer {
                 return finish()
 
             case .airPodsConnectionChanged(let isConnected):
+                state.airPodsReadiness.connected = isConnected
+                if state.trackingMode == .automatic, state.appState != .disabled {
+                    return finish(resolveAutomaticSource(&state))
+                }
                 let result = PostureEngine.stateWhenAirPodsConnectionChanges(
                     currentState: state.appState,
                     trackingSource: state.activeSource,
@@ -318,6 +392,13 @@ struct TrackingFeature: Reducer {
                 return finish()
 
             case .cameraConnected(let hasMatchingProfile, let matchingProfile):
+                state.cameraReadiness.connected = true
+                if hasMatchingProfile {
+                    state.cameraReadiness.calibrated = true
+                }
+                if state.trackingMode == .automatic, state.appState != .disabled {
+                    return finish(resolveAutomaticSource(&state))
+                }
                 let previousState = state.appState
                 let result = PostureEngine.stateWhenCameraConnects(
                     currentState: state.appState,
@@ -347,6 +428,12 @@ struct TrackingFeature: Reducer {
                 let fallbackCameraID,
                 let fallbackProfile
             ):
+                if disconnectedCameraIsSelected {
+                    state.cameraReadiness.connected = hasFallbackCamera
+                }
+                if state.trackingMode == .automatic, state.appState != .disabled {
+                    return finish(resolveAutomaticSource(&state))
+                }
                 let result = PostureEngine.stateWhenCameraDisconnects(
                     currentState: state.appState,
                     trackingSource: state.activeSource,
@@ -405,6 +492,7 @@ struct TrackingFeature: Reducer {
 
             case .runtimeDetectorStartFailed(let trackingSource):
                 state.manualSource = trackingSource
+                state.activeSource = trackingSource
                 state.appState = PostureEngine.unavailableState(for: trackingSource)
                 return finish()
 
@@ -419,9 +507,17 @@ struct TrackingFeature: Reducer {
                 }
                 return finish()
 
-            case .calibrationCompleted:
+            case .calibrationCompleted(let source):
                 state.monitoringState.reset()
                 state.lastPostureReadingTime = nil
+                // Update calibrated flag for the source that was just calibrated
+                switch source {
+                case .camera: state.cameraReadiness.calibrated = true
+                case .airpods: state.airPodsReadiness.calibrated = true
+                }
+                if state.trackingMode == .automatic {
+                    return finish(resolveAutomaticSource(&state))
+                }
                 state.appState = PostureEngine.stateWhenCalibrationCompletes()
                 return finish(run { runtime in
                     await runtime.startMonitoring()
@@ -505,6 +601,7 @@ struct TrackingFeature: Reducer {
                 )
 
                 state.manualSource = result.newSource
+                state.activeSource = result.newSource
                 state.appState = result.newState
 
                 guard result.didSwitchSource || result.shouldStartMonitoring else {
@@ -520,7 +617,61 @@ struct TrackingFeature: Reducer {
                         await runtime.startMonitoring()
                     }
                 })
+
+            case .sourceReadinessChanged(let source, let readiness):
+                switch source {
+                case .camera: state.cameraReadiness = readiness
+                case .airpods: state.airPodsReadiness = readiness
+                }
+                if state.trackingMode == .automatic, state.appState != .disabled {
+                    return finish(resolveAutomaticSource(&state))
+                }
+                return finish()
             }
+        }
+    }
+
+    // MARK: - Automatic Mode Source Resolution
+
+    private func resolveAutomaticSource(_ state: inout State) -> Effect<Action> {
+        let previousSource = state.activeSource
+        let previousAppState = state.appState
+        let prefReadiness = state.readiness(for: state.preferredSource)
+        let fbReadiness = state.readiness(for: state.fallbackSource)
+        let result = PostureEngine.resolveActiveSource(
+            preferred: state.preferredSource,
+            currentActive: state.activeSource,
+            currentState: state.appState,
+            preferredReadiness: prefReadiness,
+            fallbackReadiness: fbReadiness,
+            autoReturn: state.autoReturnEnabled
+        )
+
+        state.activeSource = result.activeSource ?? previousSource
+        state.appState = result.newState
+
+        let sourceChanged = state.activeSource != previousSource
+        let needsBeginMonitoring = result.newState == .monitoring
+            && (sourceChanged || previousAppState != .monitoring)
+        let needsStopOld = sourceChanged && previousAppState.isActive
+
+        guard sourceChanged || needsBeginMonitoring || result.newState != previousAppState else {
+            return .none
+        }
+
+        // Don't call startMonitoring() here — it sends .startMonitoringRequested which
+        // overwrites activeSource with manualSource, causing a loop. The detector switch
+        // is handled synchronously by applyTrackingStoreTransition via syncDetectorToState.
+        // We call beginMonitoringSession to set up calibration data on the new detector.
+        return run { runtime in
+            if needsStopOld {
+                await runtime.stopDetector(previousSource)
+            }
+            if needsBeginMonitoring {
+                await runtime.beginMonitoringSession()
+            }
+            await runtime.persistTrackingSource()
+            await runtime.syncUI()
         }
     }
 }
@@ -543,6 +694,7 @@ struct TrackingRuntimeClient {
     var openPrivacySettings: @Sendable () async -> Void
     var showCameraCalibrationRetryAlert: @Sendable (String?) async -> Void
     var retryCalibration: @Sendable () async -> Void
+    var startCalibrationForSource: @Sendable (TrackingSource) async -> Void
 }
 
 extension TrackingRuntimeClient {
@@ -563,7 +715,8 @@ extension TrackingRuntimeClient {
         showCalibrationPermissionDeniedAlert: {},
         openPrivacySettings: {},
         showCameraCalibrationRetryAlert: { _ in },
-        retryCalibration: {}
+        retryCalibration: {},
+        startCalibrationForSource: { _ in }
     )
 }
 

--- a/Tests/TrackingFeatureTests.swift
+++ b/Tests/TrackingFeatureTests.swift
@@ -50,7 +50,10 @@ private extension TrackingRuntimeClient {
             showCameraCalibrationRetryAlert: { message in
                 await recorder.record(.showCameraCalibrationRetryAlert(message: message))
             },
-            retryCalibration: { await recorder.record(.retryCalibration) }
+            retryCalibration: { await recorder.record(.retryCalibration) },
+            startCalibrationForSource: { source in
+                await recorder.record(.startCalibrationForSource(source))
+            }
         )
     }
 }
@@ -475,6 +478,7 @@ final class TrackingFeatureTests: XCTestCase {
             )
         ) {
             $0.appState = .paused(.noProfile)
+            $0.cameraReadiness.connected = true
         }
         await store.finish()
         await assertIntents([.switchCamera(.fallback())], recorder: recorder)
@@ -496,6 +500,7 @@ final class TrackingFeatureTests: XCTestCase {
         )
 
         await store.send(.airPodsConnectionChanged(true)) {
+            $0.airPodsReadiness.connected = true
             $0.appState = .monitoring
         }
         await store.finish()
@@ -745,7 +750,8 @@ final class TrackingFeatureTests: XCTestCase {
             recorder: recorder
         )
 
-        await store.send(.calibrationCompleted) {
+        await store.send(.calibrationCompleted(source: .airpods)) {
+            $0.airPodsReadiness.calibrated = true
             $0.appState = .monitoring
         }
         await store.finish()
@@ -768,6 +774,8 @@ final class TrackingFeatureTests: XCTestCase {
         )
 
         await store.send(.cameraConnected(hasMatchingProfile: true)) {
+            $0.cameraReadiness.connected = true
+            $0.cameraReadiness.calibrated = true
             $0.appState = .monitoring
         }
         await store.finish()
@@ -926,6 +934,7 @@ final class TrackingFeatureTests: XCTestCase {
         await store.send(.switchTrackingSource(.airpods, isNewSourceCalibrated: false)) {
             $0.appState = .paused(.noProfile)
             $0.manualSource = .airpods
+            $0.activeSource = .airpods
         }
         await store.finish()
         await assertIntents(
@@ -955,6 +964,7 @@ final class TrackingFeatureTests: XCTestCase {
         await store.send(.switchTrackingSource(.airpods, isNewSourceCalibrated: true)) {
             $0.appState = .monitoring
             $0.manualSource = .airpods
+            $0.activeSource = .airpods
         }
         await store.finish()
         await assertIntents(
@@ -983,5 +993,461 @@ final class TrackingFeatureTests: XCTestCase {
         }
 
         await store.send(.switchTrackingSource(.camera, isNewSourceCalibrated: true))
+    }
+
+    // MARK: - Automatic Mode Tests
+
+    private func readyReadiness() -> TrackingSourceReadiness {
+        TrackingSourceReadiness(permissionGranted: true, connected: true, calibrated: true, available: true)
+    }
+
+    private func connectedNotCalibrated() -> TrackingSourceReadiness {
+        TrackingSourceReadiness(permissionGranted: true, connected: true, calibrated: false, available: true)
+    }
+
+    private func disconnectedCalibrated() -> TrackingSourceReadiness {
+        TrackingSourceReadiness(permissionGranted: true, connected: false, calibrated: true, available: true)
+    }
+
+    // MARK: setTrackingMode(.automatic)
+
+    @MainActor
+    func testSetTrackingModeAutomaticWithPreferredReadySwitchesToPreferred() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .manual,
+                manualSource: .camera,
+                preferredSource: .airpods,
+                activeSource: .camera,
+                cameraReadiness: readyReadiness(),
+                airPodsReadiness: readyReadiness()
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.setTrackingMode(.automatic)) {
+            $0.trackingMode = .automatic
+            $0.activeSource = .airpods
+        }
+        await store.finish()
+        await assertIntents(
+            [.stopDetector(.camera), .beginMonitoringSession, .persistTrackingSource, .syncUI],
+            recorder: recorder
+        )
+    }
+
+    @MainActor
+    func testSetTrackingModeAutomaticWithPreferredNotReadyFallsBack() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .manual,
+                manualSource: .camera,
+                preferredSource: .airpods,
+                activeSource: .camera,
+                cameraReadiness: readyReadiness(),
+                airPodsReadiness: disconnectedCalibrated()
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.setTrackingMode(.automatic)) {
+            $0.trackingMode = .automatic
+            // Camera stays active as fallback, no source change
+        }
+        await store.finish()
+        await assertIntents([], recorder: recorder)
+    }
+
+    @MainActor
+    func testSetTrackingModeAutomaticWithNeitherReadyPauses() async {
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .manual,
+                manualSource: .camera,
+                preferredSource: .airpods,
+                activeSource: .camera,
+                cameraReadiness: disconnectedCalibrated(),
+                airPodsReadiness: disconnectedCalibrated()
+            )
+        )
+
+        await store.send(.setTrackingMode(.automatic)) {
+            $0.trackingMode = .automatic
+            $0.appState = .paused(.airPodsRemoved)
+        }
+    }
+
+    // MARK: setTrackingMode(.manual) from automatic
+
+    @MainActor
+    func testSetTrackingModeManualFromAutomaticSwitchesSourceAndBeginsMonitoring() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .automatic,
+                manualSource: .camera,
+                preferredSource: .airpods,
+                activeSource: .airpods,
+                cameraReadiness: readyReadiness(),
+                airPodsReadiness: readyReadiness()
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.setTrackingMode(.manual)) {
+            $0.trackingMode = .manual
+            $0.activeSource = .camera
+        }
+        await store.finish()
+        await assertIntents([.beginMonitoringSession], recorder: recorder)
+    }
+
+    @MainActor
+    func testSetTrackingModeManualSameSourceNoBeginMonitoring() async {
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .automatic,
+                manualSource: .camera,
+                preferredSource: .camera,
+                activeSource: .camera,
+                cameraReadiness: readyReadiness(),
+                airPodsReadiness: readyReadiness()
+            )
+        )
+
+        await store.send(.setTrackingMode(.manual)) {
+            $0.trackingMode = .manual
+        }
+    }
+
+    // MARK: setPreferredSource
+
+    @MainActor
+    func testSetPreferredSourceSwitchesActiveInAutomatic() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .automatic,
+                manualSource: .camera,
+                preferredSource: .airpods,
+                activeSource: .airpods,
+                cameraReadiness: readyReadiness(),
+                airPodsReadiness: readyReadiness()
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.setPreferredSource(.camera)) {
+            $0.preferredSource = .camera
+            $0.activeSource = .camera
+        }
+        await store.finish()
+        await assertIntents(
+            [.stopDetector(.airpods), .beginMonitoringSession, .persistTrackingSource, .syncUI],
+            recorder: recorder
+        )
+    }
+
+    @MainActor
+    func testSetPreferredSourceInManualModeNoResolve() async {
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .manual,
+                manualSource: .camera,
+                preferredSource: .camera,
+                activeSource: .camera,
+                cameraReadiness: readyReadiness(),
+                airPodsReadiness: readyReadiness()
+            )
+        )
+
+        await store.send(.setPreferredSource(.airpods)) {
+            $0.preferredSource = .airpods
+        }
+    }
+
+    // MARK: setManualSource
+
+    @MainActor
+    func testSetManualSourceWhileMonitoringBeginsNewSession() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .manual,
+                manualSource: .camera,
+                activeSource: .camera
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.setManualSource(.airpods)) {
+            $0.manualSource = .airpods
+            $0.activeSource = .airpods
+        }
+        await store.finish()
+        await assertIntents([.beginMonitoringSession], recorder: recorder)
+    }
+
+    @MainActor
+    func testSetManualSourceSameSourceNoEffect() async {
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .manual,
+                manualSource: .camera,
+                activeSource: .camera
+            )
+        )
+
+        await store.send(.setManualSource(.camera))
+    }
+
+    @MainActor
+    func testSetManualSourceWhileNotMonitoringNoBeginSession() async {
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .paused(.noProfile),
+                trackingMode: .manual,
+                manualSource: .camera,
+                activeSource: .camera
+            )
+        )
+
+        await store.send(.setManualSource(.airpods)) {
+            $0.manualSource = .airpods
+            $0.activeSource = .airpods
+        }
+    }
+
+    // MARK: calibrationCompleted in automatic mode
+
+    @MainActor
+    func testCalibrationCompletedInAutomaticModeResolvesAndBeginsMonitoring() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .calibrating,
+                trackingMode: .automatic,
+                manualSource: .camera,
+                preferredSource: .camera,
+                activeSource: .camera,
+                cameraReadiness: connectedNotCalibrated(),
+                airPodsReadiness: readyReadiness()
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.calibrationCompleted(source: .camera)) {
+            $0.cameraReadiness.calibrated = true
+            $0.activeSource = .camera
+            $0.appState = .monitoring
+        }
+        await store.finish()
+        await assertIntents(
+            [.beginMonitoringSession, .persistTrackingSource, .syncUI],
+            recorder: recorder
+        )
+    }
+
+    @MainActor
+    func testCalibrationCompletedForFallbackInAutomaticAutoReturnsToPreferred() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .calibrating,
+                trackingMode: .automatic,
+                manualSource: .camera,
+                preferredSource: .airpods,
+                activeSource: .camera,
+                cameraReadiness: readyReadiness(),
+                airPodsReadiness: connectedNotCalibrated()
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.calibrationCompleted(source: .airpods)) {
+            $0.airPodsReadiness.calibrated = true
+            $0.activeSource = .airpods
+            $0.appState = .monitoring
+        }
+        await store.finish()
+        await assertIntents(
+            [.stopDetector(.camera), .beginMonitoringSession, .persistTrackingSource, .syncUI],
+            recorder: recorder
+        )
+    }
+
+    // MARK: Auto-return via airPodsConnectionChanged
+
+    @MainActor
+    func testAirPodsReconnectInAutomaticModeAutoReturnsToPreferred() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .automatic,
+                manualSource: .camera,
+                preferredSource: .airpods,
+                activeSource: .camera,
+                cameraReadiness: readyReadiness(),
+                airPodsReadiness: disconnectedCalibrated()
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.airPodsConnectionChanged(true)) {
+            $0.airPodsReadiness.connected = true
+            $0.activeSource = .airpods
+        }
+        await store.finish()
+        await assertIntents(
+            [.stopDetector(.camera), .beginMonitoringSession, .persistTrackingSource, .syncUI],
+            recorder: recorder
+        )
+    }
+
+    @MainActor
+    func testAirPodsDisconnectInAutomaticModeFallsBackToCamera() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .automatic,
+                manualSource: .camera,
+                preferredSource: .airpods,
+                activeSource: .airpods,
+                cameraReadiness: readyReadiness(),
+                airPodsReadiness: readyReadiness()
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.airPodsConnectionChanged(false)) {
+            $0.airPodsReadiness.connected = false
+            $0.activeSource = .camera
+        }
+        await store.finish()
+        await assertIntents(
+            [.stopDetector(.airpods), .beginMonitoringSession, .persistTrackingSource, .syncUI],
+            recorder: recorder
+        )
+    }
+
+    // MARK: sourceReadinessChanged
+
+    @MainActor
+    func testSourceReadinessChangedInAutomaticModeTriggersResolve() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .paused(.airPodsRemoved),
+                trackingMode: .automatic,
+                manualSource: .camera,
+                preferredSource: .airpods,
+                activeSource: .camera,
+                cameraReadiness: readyReadiness(),
+                airPodsReadiness: disconnectedCalibrated()
+            ),
+            recorder: recorder
+        )
+
+        let ready = readyReadiness()
+        await store.send(.sourceReadinessChanged(source: .airpods, readiness: ready)) {
+            $0.airPodsReadiness = ready
+            $0.activeSource = .airpods
+            $0.appState = .monitoring
+        }
+        await store.finish()
+        // No stopDetector because previous state was paused (detector wasn't running)
+        await assertIntents(
+            [.beginMonitoringSession, .persistTrackingSource, .syncUI],
+            recorder: recorder
+        )
+    }
+
+    @MainActor
+    func testSourceReadinessChangedInManualModeNoResolve() async {
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                trackingMode: .manual,
+                manualSource: .camera,
+                activeSource: .camera,
+                cameraReadiness: readyReadiness()
+            )
+        )
+
+        let ready = readyReadiness()
+        await store.send(.sourceReadinessChanged(source: .airpods, readiness: ready)) {
+            $0.airPodsReadiness = ready
+        }
+    }
+
+    // MARK: PostureEngine.resolveActiveSource
+
+    @MainActor
+    func testResolveActiveSourcePreferredReadyUsesPreferred() {
+        let result = PostureEngine.resolveActiveSource(
+            preferred: .airpods,
+            currentActive: .camera,
+            currentState: .monitoring,
+            preferredReadiness: readyReadiness(),
+            fallbackReadiness: readyReadiness(),
+            autoReturn: true
+        )
+        XCTAssertEqual(result.activeSource, .airpods)
+        XCTAssertEqual(result.newState, .monitoring)
+    }
+
+    @MainActor
+    func testResolveActiveSourcePreferredNotReadyUsesFallback() {
+        let result = PostureEngine.resolveActiveSource(
+            preferred: .airpods,
+            currentActive: .camera,
+            currentState: .monitoring,
+            preferredReadiness: disconnectedCalibrated(),
+            fallbackReadiness: readyReadiness(),
+            autoReturn: true
+        )
+        XCTAssertEqual(result.activeSource, .camera)
+        XCTAssertEqual(result.newState, .monitoring)
+    }
+
+    @MainActor
+    func testResolveActiveSourceNeitherReadyPauses() {
+        let result = PostureEngine.resolveActiveSource(
+            preferred: .airpods,
+            currentActive: .camera,
+            currentState: .monitoring,
+            preferredReadiness: disconnectedCalibrated(),
+            fallbackReadiness: disconnectedCalibrated(),
+            autoReturn: true
+        )
+        XCTAssertNil(result.activeSource)
+        XCTAssertEqual(result.newState, .paused(.airPodsRemoved))
+    }
+
+    @MainActor
+    func testResolveActiveSourcePreferredConnectedNotCalibratedPausesNoProfile() {
+        let result = PostureEngine.resolveActiveSource(
+            preferred: .airpods,
+            currentActive: .camera,
+            currentState: .monitoring,
+            preferredReadiness: connectedNotCalibrated(),
+            fallbackReadiness: TrackingSourceReadiness(),
+            autoReturn: true
+        )
+        XCTAssertNil(result.activeSource)
+        XCTAssertEqual(result.newState, .paused(.noProfile))
     }
 }

--- a/Tests/TrackingReducerScenarioHarness.swift
+++ b/Tests/TrackingReducerScenarioHarness.swift
@@ -49,7 +49,10 @@ private extension TrackingRuntimeClient {
             showCameraCalibrationRetryAlert: { message in
                 await recorder.append(.showCameraCalibrationRetryAlert(message: message))
             },
-            retryCalibration: { await recorder.append(.retryCalibration) }
+            retryCalibration: { await recorder.append(.retryCalibration) },
+            startCalibrationForSource: { source in
+                await recorder.append(.startCalibrationForSource(source))
+            }
         )
     }
 }
@@ -68,14 +71,20 @@ struct TrackingReducerScenarioHarness {
         trackingSource: TrackingSource,
         isCalibrated: Bool,
         detectorAvailable: Bool,
-        stateBeforeLock: AppState? = nil
+        stateBeforeLock: AppState? = nil,
+        trackingMode: TrackingMode = .manual,
+        preferredSource: TrackingSource = .camera,
+        cameraReadiness: TrackingSourceReadiness = TrackingSourceReadiness(),
+        airPodsReadiness: TrackingSourceReadiness = TrackingSourceReadiness()
     ) {
         reducerState = TrackingFeature.State(
             appState: state,
-            trackingMode: .manual,
+            trackingMode: trackingMode,
             manualSource: trackingSource,
-            preferredSource: .camera,
-            autoReturnEnabled: false,
+            preferredSource: preferredSource,
+            autoReturnEnabled: true,
+            cameraReadiness: cameraReadiness,
+            airPodsReadiness: airPodsReadiness,
             stateBeforeLock: stateBeforeLock
         )
         self.isCalibrated = isCalibrated
@@ -95,6 +104,7 @@ struct TrackingReducerScenarioHarness {
             reducerState.appState = nextState
         case .setTrackingSource(let source):
             reducerState.manualSource = source
+            reducerState.activeSource = source
         case .setCalibrated(let calibrated):
             isCalibrated = calibrated
         case .setDetectorAvailable(let available):
@@ -136,7 +146,7 @@ struct TrackingReducerScenarioHarness {
         case .calibrationCancelled:
             intents = await dispatch(.calibrationCancelled(isCalibrated: isCalibrated))
         case .calibrationCompleted:
-            intents = await dispatch(.calibrationCompleted)
+            intents = await dispatch(.calibrationCompleted(source: reducerState.activeSource))
             isCalibrated = true
         case .airPodsConnectionChanged(let isConnected):
             self.isConnected = isConnected
@@ -177,6 +187,12 @@ struct TrackingReducerScenarioHarness {
             intents = await dispatch(.screenLocked)
         case .screenUnlocked:
             intents = await dispatch(.screenUnlocked)
+        case .setTrackingMode(let mode):
+            intents = await dispatch(.setTrackingMode(mode))
+        case .setPreferredSource(let source):
+            intents = await dispatch(.setPreferredSource(source))
+        case .sourceReadinessChanged(let source, let readiness):
+            intents = await dispatch(.sourceReadinessChanged(source: source, readiness: readiness))
         }
 
         let startMonitoringRequested = intents.contains { intent in

--- a/Tests/TrackingScenarioHarness.swift
+++ b/Tests/TrackingScenarioHarness.swift
@@ -33,6 +33,9 @@ enum TrackingScenarioEvent: Equatable {
     case cameraSelectionChanged
     case screenLocked
     case screenUnlocked
+    case setTrackingMode(TrackingMode)
+    case setPreferredSource(TrackingSource)
+    case sourceReadinessChanged(source: TrackingSource, readiness: TrackingSourceReadiness)
 }
 
 struct TrackingScenarioSnapshot: Equatable {
@@ -235,6 +238,9 @@ struct TrackingScenarioHarness {
             stateBeforeLock = result.stateBeforeLock
             restartMonitoringRequested = result.shouldRestartMonitoring
             startMonitoringRequested = result.shouldRestartMonitoring
+        case .setTrackingMode, .setPreferredSource, .sourceReadinessChanged:
+            // These are handled by the reducer harness only
+            break
         }
 
         record(


### PR DESCRIPTION
Add automatic mode that intelligently switches between Camera and AirPods based on availability, letting users pick a preferred source with automatic fallback and auto-return when the preferred device reconnects.

Core changes:
- Add resolveActiveSource() to PostureEngine for deterministic source selection based on readiness (connected + calibrated)
- Add per-source TrackingSourceReadiness tracking in reducer state
- Promote activeSource from computed property to stored field
- Handle source resolution on mode/preference changes, calibration completion, device connection events, and readiness updates
- Ensure beginMonitoringSession() fires on all source transitions including calibrating → monitoring (not just paused → monitoring)

Settings UI:
- Add mode picker (Manual/Automatic) and preferred source picker
- Add DeviceStatusRow with calibration status, connection, active badge
- Show both device rows in automatic mode, single row in manual mode
- Warning banner when preferred device needs calibration
- Fix callback cleanup: use windowWillClose instead of onDisappear to prevent calibration window from nil-ing settings callbacks

Bug fixes:
- Fix AirPods isConnected to check paired status via CMHeadphoneMotionManager, not active motion data streaming
- Fix crash on startup: guard MenuBarManager methods against nil status items during loadSettings() before menu bar setup
- Fix permission alert showing wrong source: use calibratingSource instead of manualSource for alert text and privacy deep link
- Fix calibratingSource cleared before permission alert shown
- Deep-link to specific privacy panes (Privacy_Camera, Privacy_Motion)
- Fix onboarding window clipping with preferredContentSize sizing
- Refresh readiness before setPreferredSource/setTrackingMode actions

Tests: 20 new tests covering automatic mode resolution, source switching, auto-return, calibration completion, and PostureEngine.resolveActiveSource. All 386 tests pass.