### PR TITLE
Fix menu bar icon missing on Intel Macs (#86)

### DIFF
--- a/Sources/MenuBar.swift
+++ b/Sources/MenuBar.swift
@@ -21,7 +21,11 @@ final class MenuBarManager {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 
         if let button = statusItem.button {
-            button.image = MenuBarIcon.good.image
+            let icon = MenuBarIcon.good.image
+            button.image = icon
+            if icon == nil {
+                button.title = "Dorso"
+            }
         }
 
         let menu = NSMenu()
@@ -81,7 +85,10 @@ final class MenuBarManager {
     func updateStatus(text: String, icon: MenuBarIcon) {
         guard isSetUp else { return }
         statusMenuItem.title = text
-        statusItem.button?.image = icon.image
+        guard let button = statusItem.button else { return }
+        let iconImage = icon.image
+        button.image = iconImage
+        button.title = iconImage == nil ? "Dorso" : ""
     }
 
     func updateEnabledState(_ enabled: Bool) {

--- a/Sources/Models.swift
+++ b/Sources/Models.swift
@@ -76,22 +76,13 @@ enum MenuBarIcon: String, CaseIterable {
     var image: NSImage? {
         // Try to load custom PDF icon from Resources/Icons/
         if let url = Bundle.main.url(forResource: rawValue, withExtension: "pdf", subdirectory: "Icons"),
-           let customImage = NSImage(contentsOf: url) {
-            // Resize to menu bar height (18pt) while preserving aspect ratio
+           let customImage = NSImage(contentsOf: url),
+           customImage.size.width > 0, customImage.size.height > 0 {
             let targetHeight: CGFloat = 18
             let aspectRatio = customImage.size.width / customImage.size.height
-            let targetWidth = targetHeight * aspectRatio
-            let targetSize = NSSize(width: targetWidth, height: targetHeight)
-
-            let resizedImage = NSImage(size: targetSize)
-            resizedImage.lockFocus()
-            customImage.draw(in: NSRect(origin: .zero, size: targetSize),
-                           from: NSRect(origin: .zero, size: customImage.size),
-                           operation: .copy,
-                           fraction: 1.0)
-            resizedImage.unlockFocus()
-            resizedImage.isTemplate = true
-            return resizedImage
+            customImage.size = NSSize(width: targetHeight * aspectRatio, height: targetHeight)
+            customImage.isTemplate = true
+            return customImage
         }
 
         // Fall back to SF Symbol

--- a/Tests/ModelsTests.swift
+++ b/Tests/ModelsTests.swift
@@ -1,7 +1,38 @@
 import XCTest
+#if canImport(AppKit)
+import AppKit
+#endif
 @testable import DorsoCore
 
 final class ModelsTests: XCTestCase {
+
+    // MARK: - MenuBarIcon Tests
+
+    #if canImport(AppKit)
+    func testMenuBarIconImageNonNilForAllCases() {
+        for icon in MenuBarIcon.allCases {
+            XCTAssertNotNil(icon.image, "MenuBarIcon.\(icon.rawValue).image returned nil — status item would have zero width and become invisible")
+        }
+    }
+
+    func testMenuBarIconImageHasNonZeroSize() {
+        for icon in MenuBarIcon.allCases {
+            guard let image = icon.image else {
+                XCTFail("Icon \(icon.rawValue) returned nil image")
+                continue
+            }
+            XCTAssertGreaterThan(image.size.width, 0, "Icon \(icon.rawValue) has zero width")
+            XCTAssertGreaterThan(image.size.height, 0, "Icon \(icon.rawValue) has zero height")
+        }
+    }
+
+    func testMenuBarIconImageIsTemplate() {
+        for icon in MenuBarIcon.allCases {
+            XCTAssertTrue(icon.image?.isTemplate ?? false, "Icon \(icon.rawValue) is not a template image — menu bar tinting for light/dark mode will break")
+        }
+    }
+    #endif
+
 
     // MARK: - AppState Tests
 


### PR DESCRIPTION
## Summary
- Load PDF menu bar icons as vector images instead of rasterizing through `NSImage.lockFocus()/unlockFocus()`. The rasterization path could silently produce an empty image, leaving a variable-length `NSStatusItem` at zero width — invisible in the menu bar.
- Add a defensive `"Dorso"` title fallback in `MenuBarManager` so the status item always has hit-testable content even if image loading fails.
- Add regression tests asserting every `MenuBarIcon` case returns a non-nil, non-zero-size template image.

## Why this fixes #86
The reporter (Intel Mac) described the app running normally (blur overlay triggers on lean) but the menu bar icon never appearing after calibration. That's the exact signature of an `NSStatusItem` whose button image is either nil or zero-sized — `variableLength` collapses to zero width and becomes invisible.

The existing implementation rasterized each PDF by resizing via `lockFocus/unlockFocus`. That offscreen drawing path is fragile: if the current graphics context isn't fully ready when the status item is first set up during `applicationDidFinishLaunching`, the drawn output can be blank. Switching to vector scaling (`customImage.size = ...; customImage.isTemplate = true`) sidesteps the rasterization entirely — NSImage handles PDF scaling and template tinting natively for the menu bar.

The fix isn't conditional on architecture because I don't have hard evidence this is strictly Intel-specific — it's a fragile code path any machine could hit under the right timing. Removing the fragility is a win regardless.

## Test plan
- [x] Universal build succeeds (`./build.sh`, confirmed `Architectures: x86_64 arm64`)
- [x] New tests in `ModelsTests.swift` pass (`swift test --filter testMenuBarIcon`)
- [ ] Manual verification on Apple Silicon: menu bar icon renders correctly in light and dark mode
- [ ] Manual verification on Intel Mac (if available): menu bar icon appears after calibration — ideally confirmed by original reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)