### PR TITLE
Full screen overlay follow-ups: fix vanishing overlay on rebuild, consolidate settings sync

### DIFF
--- a/Sources/AppDelegate+Overlay.swift
+++ b/Sources/AppDelegate+Overlay.swift
@@ -6,7 +6,7 @@ extension AppDelegate {
 
     func setupOverlayWindows() {
         for screen in NSScreen.screens {
-            let frame = useFullScreenOverlay ? screen.frame : screen.visibleFrame
+            let frame = screen.overlayFrame(fullScreen: useFullScreenOverlay)
             let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
             window.isOpaque = false
             window.backgroundColor = .clear
@@ -28,17 +28,30 @@ extension AppDelegate {
         }
     }
 
+    /// Pushes the settings that warning overlay windows are built from into the
+    /// manager. Every path that sets up or rebuilds the manager's windows must
+    /// call this first so the manager never renders from stale settings.
+    func syncWarningOverlaySettings() {
+        warningOverlayManager.mode = activeWarningMode
+        warningOverlayManager.warningColor = activeWarningColor
+        warningOverlayManager.useFullScreenOverlay = useFullScreenOverlay
+    }
+
     func rebuildOverlayWindows() {
         for window in windows {
             window.orderOut(nil)
         }
         windows.removeAll()
         blurViews.removeAll()
+        // New blur views start at alpha 0 and fresh window numbers carry no CGS
+        // blur; reset the ramp so updateBlur repaints instead of skipping when
+        // currentBlurRadius == targetBlurRadius.
+        currentBlurRadius = 0
         withAccessoryActivationPolicy {
             setupOverlayWindows()
 
             if activeWarningMode.usesWarningOverlay {
-                warningOverlayManager.useFullScreenOverlay = useFullScreenOverlay
+                syncWarningOverlaySettings()
                 warningOverlayManager.rebuildOverlayWindows()
             }
         }
@@ -63,10 +76,10 @@ extension AppDelegate {
         #endif
     }
 
-    func switchWarningMode(to newMode: WarningMode) {
+    func switchWarningMode() {
         clearBlur()
 
-        warningOverlayManager.mode = newMode
+        syncWarningOverlaySettings()
 
         warningOverlayManager.currentIntensity = 0
         warningOverlayManager.targetIntensity = 0
@@ -84,9 +97,7 @@ extension AppDelegate {
         warningOverlayManager.windows.removeAll()
         warningOverlayManager.overlayViews.removeAll()
 
-        if newMode.usesWarningOverlay {
-            warningOverlayManager.warningColor = activeWarningColor
-            warningOverlayManager.useFullScreenOverlay = useFullScreenOverlay
+        if activeWarningMode.usesWarningOverlay {
             withAccessoryActivationPolicy {
                 warningOverlayManager.setupOverlayWindows()
             }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -343,9 +343,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         withAccessoryActivationPolicy {
             setupOverlayWindows()
 
-            warningOverlayManager.mode = activeWarningMode
-            warningOverlayManager.warningColor = activeWarningColor
-            warningOverlayManager.useFullScreenOverlay = useFullScreenOverlay
+            syncWarningOverlaySettings()
             appliedWarningColorData = activeSettingsProfile?.warningColorData
             if activeWarningMode.usesWarningOverlay {
                 warningOverlayManager.setupOverlayWindows()
@@ -1283,7 +1281,7 @@ extension AppDelegate.TrackingCoordinator {
         guard appDelegate.setupComplete else { return }
 
         if appDelegate.warningOverlayManager.mode != appDelegate.activeWarningMode {
-            appDelegate.switchWarningMode(to: appDelegate.activeWarningMode)
+            appDelegate.switchWarningMode()
         }
 
         let desiredColorData = appDelegate.activeSettingsProfile?.warningColorData

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -929,7 +929,7 @@ struct SettingsView: View {
                         .frame(maxWidth: .infinity)
                         .onChange(of: warningMode) { newValue in
                             settingsProfileManager.updateActiveProfile(warningMode: newValue)
-                            appDelegate.switchWarningMode(to: newValue)
+                            appDelegate.switchWarningMode()
                         }
 
                     InlineColorPicker(color: $warningColor)

--- a/Sources/WarningOverlay.swift
+++ b/Sources/WarningOverlay.swift
@@ -345,6 +345,15 @@ class SolidOverlayView: NSView {
 
 // MARK: - Warning Overlay Manager
 
+extension NSScreen {
+    /// The frame an overlay window should cover: the whole screen (over the
+    /// dock and menu bar) or just the visible working area. Blur and warning
+    /// overlays must use the same frame to stay pixel-aligned per screen.
+    func overlayFrame(fullScreen: Bool) -> NSRect {
+        fullScreen ? frame : visibleFrame
+    }
+}
+
 class WarningOverlayManager {
     var windows: [NSWindow] = []
     var overlayViews: [NSView] = []
@@ -356,7 +365,7 @@ class WarningOverlayManager {
 
     func setupOverlayWindows() {
         for screen in NSScreen.screens {
-            let frame = useFullScreenOverlay ? screen.frame : screen.visibleFrame
+            let frame = screen.overlayFrame(fullScreen: useFullScreenOverlay)
             let window = NSWindow(
                 contentRect: frame,
                 styleMask: [.borderless],
@@ -403,6 +412,9 @@ class WarningOverlayManager {
         }
         windows.removeAll()
         overlayViews.removeAll()
+        // New views start at intensity 0; reset the ramp so updateWarning
+        // repaints them instead of skipping when currentIntensity == targetIntensity.
+        currentIntensity = 0
         setupOverlayWindows()
     }
 


### PR DESCRIPTION
Follow-up to #92 (branched from its head commit, so this diff will reduce to just the fixes once #92 merges).

## Bug fix

Rebuilding the overlay windows (flipping the new Full Screen Overlay toggle, or a display configuration change) recreated the blur and warning views at zero intensity, while the tracked `currentBlurRadius`/`currentIntensity` kept their old values. `updateBlur`'s `current == target` guard then skipped repainting, so an actively displayed warning or privacy blur silently disappeared until the posture/away state next changed. The rebuild paths now reset the ramp state so the effect re-applies to the fresh windows.

## Cleanups

- Added `syncWarningOverlaySettings()` as the single point that pushes mode, warning color, and `useFullScreenOverlay` into `WarningOverlayManager`, replacing the hand-copied assignments at each setup/rebuild call site.
- `switchWarningMode()` no longer takes a mode parameter: both callers already updated the active profile first, so it now reads from the profile directly.
- Both overlay window builders share `NSScreen.overlayFrame(fullScreen:)` instead of duplicating the `screen.frame : screen.visibleFrame` ternary, keeping blur and warning overlays pixel-aligned.

## Testing

Built and ran locally: with a warning fully active (and separately, away-blur fully applied), flipping the Full Screen Overlay toggle now re-applies the effect on the rebuilt windows instead of leaving them blank. Mode and color switching behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)