### PR TITLE
Fix Dorso staying in Dock and Cmd+Tab after any window is opened

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -521,12 +521,16 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     func restoreAccessoryActivationPolicyIfNeeded(excluding windowToIgnore: NSWindow? = nil) {
         guard !showInDock else { return }
 
-        let hasOtherVisibleWindows = NSApp.windows.contains { window in
+        // Only titled windows (Settings, Support, Analytics, Onboarding) justify
+        // staying .regular. The borderless overlay windows are visible for the
+        // app's entire lifetime, so counting them here would keep the app in
+        // the Dock and Cmd+Tab switcher forever after the first window opened.
+        let hasOtherVisibleTitledWindows = NSApp.windows.contains { window in
             guard window != windowToIgnore else { return false }
-            return window.isVisible && !window.isMiniaturized
+            return window.isVisible && !window.isMiniaturized && window.styleMask.contains(.titled)
         }
 
-        if !hasOtherVisibleWindows {
+        if !hasOtherVisibleTitledWindows {
             NSApp.setActivationPolicy(.accessory)
         }
     }

--- a/Sources/CalibrationWindow.swift
+++ b/Sources/CalibrationWindow.swift
@@ -541,6 +541,10 @@ class CalibrationWindowController: NSObject {
         if let policy = activationPolicyToRestore {
             NSApp.setActivationPolicy(policy)
             activationPolicyToRestore = nil
+            // The window that had flipped the app to .regular may have closed
+            // during calibration; drop back to .accessory if nothing visible
+            // still needs .regular.
+            (NSApp.delegate as? AppDelegate)?.restoreAccessoryActivationPolicyIfNeeded()
         }
     }
 }


### PR DESCRIPTION
Fixes the Cmd+Tab visibility reported by @wensiet in #93. Thanks for the report!

## Root cause

Dorso launches as an accessory app (LSUIElement, plus an explicit `.accessory` set at startup), so the launch path was never the problem. Windows like Settings intentionally flip the app to `.regular` while open, and `restoreAccessoryActivationPolicyIfNeeded` is supposed to flip it back on close. But that helper counted every visible window, and the borderless blur overlay windows are on screen for the app's entire lifetime, so the restore never ran: opening Settings once left Dorso in the Dock and the Cmd+Tab switcher until relaunch.

## Fix

- `restoreAccessoryActivationPolicyIfNeeded` now only counts visible titled windows (Settings, Support, Analytics, Onboarding) when deciding whether the app still needs `.regular`. All overlay windows are borderless, so the styleMask split is exact.
- Calibration cleanup now re-derives the policy after restoring the one it captured at start, covering the case where the originating Settings/Onboarding window closed during calibration.

Note on #93: the change there sets `.accessory` at launch, but the app is already `.accessory` at that point on every launch path, so it could not affect Cmd+Tab visibility. This PR addresses the underlying bug instead. Closes #93.

## Testing

Built and verified locally with Show in Dock off: opening Settings shows Dorso in Cmd+Tab and the Dock while the window is open (expected), and closing it now removes Dorso from both. Previously it remained until relaunch. Also verified the calibration path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)