### PR TITLE
Fix windows opening partially off-screen on multi-display setups

### DIFF
--- a/Sources/UI/AnalyticsWindow.swift
+++ b/Sources/UI/AnalyticsWindow.swift
@@ -23,7 +23,7 @@ class AnalyticsWindowController: NSWindowController, NSWindowDelegate {
         window.isReleasedWhenClosed = false
         window.titlebarAppearsTransparent = false
         window.backgroundColor = NSColor.windowBackgroundColor
-        window.center()
+        window.centerOnActiveScreen()
 
         self.init(window: window)
         window.delegate = self

--- a/Sources/UI/OnboardingWindow.swift
+++ b/Sources/UI/OnboardingWindow.swift
@@ -49,7 +49,7 @@ class OnboardingWindowController: NSObject, NSWindowDelegate {
         window.contentViewController = hostingController
         window.isReleasedWhenClosed = false
         window.delegate = self
-        window.center()
+        window.centerOnActiveScreen()
 
         self.window = window
         NSApp.setActivationPolicy(.regular)

--- a/Sources/UI/SettingsWindowController.swift
+++ b/Sources/UI/SettingsWindowController.swift
@@ -36,10 +36,12 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         window.titlebarAppearsTransparent = false
         window.backgroundColor = NSColor.windowBackgroundColor
 
-        // Restore saved position or center on screen
+        // Restore saved position, or center on the screen the user is on.
+        // A saved frame only counts if it is fully visible; a partially
+        // off-screen frame would open cut off.
         let restored = window.setFrameUsingName("SettingsWindow")
-        if !restored || !self.isWindowOnScreen(window) {
-            window.center()
+        if !restored || !window.isFullyOnScreen {
+            window.centerOnActiveScreen()
         }
 
         self.window = window
@@ -59,13 +61,11 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         appDelegate?.onActiveSourceChanged = nil
     }
 
-    private func isWindowOnScreen(_ window: NSWindow) -> Bool {
-        for screen in NSScreen.screens {
-            if screen.visibleFrame.intersects(window.frame) {
-                return true
-            }
-        }
-        return false
+    func windowDidResize(_ notification: Notification) {
+        // The window isn't user-resizable, so any resize is SwiftUI content
+        // layout (including the post-show layout that can grow the window
+        // past a screen edge). Keep the new frame fully on screen.
+        (notification.object as? NSWindow)?.constrainToVisibleScreenArea()
     }
 
     func close() {

--- a/Sources/UI/SupportWindow.swift
+++ b/Sources/UI/SupportWindow.swift
@@ -34,8 +34,8 @@ final class SupportWindowController: NSObject, NSWindowDelegate {
         window.backgroundColor = NSColor.windowBackgroundColor
 
         let restored = window.setFrameUsingName("SupportWindow")
-        if !restored || !isWindowOnScreen(window) {
-            window.center()
+        if !restored || !window.isFullyOnScreen {
+            window.centerOnActiveScreen()
         }
 
         self.window = window
@@ -51,13 +51,10 @@ final class SupportWindowController: NSObject, NSWindowDelegate {
         }
     }
 
-    private func isWindowOnScreen(_ window: NSWindow) -> Bool {
-        for screen in NSScreen.screens {
-            if screen.visibleFrame.intersects(window.frame) {
-                return true
-            }
-        }
-        return false
+    func windowDidResize(_ notification: Notification) {
+        // Content-driven resizes only (window isn't user-resizable);
+        // keep the new frame fully on screen.
+        (notification.object as? NSWindow)?.constrainToVisibleScreenArea()
     }
 
     func close() {

--- a/Sources/UI/WindowPlacement.swift
+++ b/Sources/UI/WindowPlacement.swift
@@ -1,0 +1,59 @@
+import AppKit
+
+extension NSWindow {
+    /// The screen the user is interacting with: the one containing the mouse
+    /// pointer (they just clicked the menu bar there). Falls back to the
+    /// window's screen, then the main screen.
+    private var activeScreen: NSScreen? {
+        let mouse = NSEvent.mouseLocation
+        return NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) }
+            ?? screen ?? NSScreen.main ?? NSScreen.screens.first
+    }
+
+    /// True when the frame sits entirely inside some screen's visible area
+    /// (menu bar and Dock excluded). A restored frame that fails this test
+    /// would render partially cut off and should be re-centered instead.
+    var isFullyOnScreen: Bool {
+        NSScreen.screens.contains { $0.visibleFrame.contains(frame) }
+    }
+
+    /// Centers on the screen containing the mouse pointer. `center()` uses
+    /// whichever screen the (possibly never-shown) window is nominally on,
+    /// which on multi-display setups is often not where the user is looking.
+    func centerOnActiveScreen() {
+        guard let visible = activeScreen?.visibleFrame else {
+            center()
+            return
+        }
+        setFrameOrigin(NSPoint(
+            x: visible.midX - frame.width / 2,
+            // Match center()'s placement: somewhat above the vertical middle.
+            y: visible.minY + (visible.height - frame.height) * 2 / 3
+        ))
+    }
+
+    /// Moves the window the minimum distance needed to sit fully inside the
+    /// visible area of the screen it mostly occupies. If the window is
+    /// larger than that area, the title bar stays reachable.
+    func constrainToVisibleScreenArea() {
+        guard !isFullyOnScreen else { return }
+
+        let target = NSScreen.screens.max(by: { overlapArea(with: $0) < overlapArea(with: $1) })
+        guard let visible = (overlapArea(with: target) > 0 ? target : activeScreen)?.visibleFrame else { return }
+
+        var origin = frame.origin
+        origin.x = frame.width >= visible.width
+            ? visible.minX
+            : min(max(origin.x, visible.minX), visible.maxX - frame.width)
+        origin.y = frame.height >= visible.height
+            ? visible.maxY - frame.height
+            : min(max(origin.y, visible.minY), visible.maxY - frame.height)
+        setFrameOrigin(origin)
+    }
+
+    private func overlapArea(with screen: NSScreen?) -> CGFloat {
+        guard let screen else { return 0 }
+        let overlap = screen.visibleFrame.intersection(frame)
+        return overlap.isNull ? 0 : overlap.width * overlap.height
+    }
+}


### PR DESCRIPTION
## Summary

Settings (and its sibling windows) could open half cut off on a multi-display setup. Two causes:

1. The window was centered before it was ever shown, relative to whichever screen AppKit nominally had it on, and at its pre-layout size. SwiftUI's post-show layout then grew the window from its top-left corner, which can push it across a screen edge.
2. A remembered position counted as valid if it merely *intersected* a screen, so a frame saved half off-screen was restored cut off on every subsequent open.

## Fix

New shared `NSWindow` placement helpers (`Sources/UI/WindowPlacement.swift`), applied to the Settings, Support, Analytics, and Onboarding windows:

- **First open**: center on the screen containing the mouse pointer, which is where the user just clicked the menu bar, instead of whichever screen AppKit picks.
- **Reopen**: restore the last-closed position only if the frame is fully visible on some screen; otherwise re-center.
- **Content resizes**: the windows are not user-resizable, so every resize is SwiftUI layout; `windowDidResize` now clamps the grown frame back fully on screen, keeping the title bar reachable. Event-driven, no timing hacks.

## Test plan

- [x] `swift test`: 404 tests, 0 failures
- [x] Fresh start (settings + permissions reset), onboarding, calibration on a two-display setup
- [ ] Manual: open Settings from each display's menu bar (centers on that screen), move it, close, reopen (restores position), disconnect the display it was on and reopen (re-centers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)