### PR TITLE
Add "Pause on battery" setting to save power when unplugged

### DIFF
--- a/Sources/AppDelegate/AppDelegate+DeviceEvents.swift
+++ b/Sources/AppDelegate/AppDelegate+DeviceEvents.swift
@@ -75,7 +75,16 @@ extension AppDelegate {
     }
 
     func handleScreenUnlocked() async {
+        // The power source may have changed while the lid was closed or the
+        // screen locked; refresh so the unlock transition sees the true state.
+        await sendTrackingAction(.powerSourceChanged(isOnBattery: powerSourceObserver.isOnBattery))
         await sendTrackingAction(.screenUnlocked)
+    }
+
+    // MARK: - Power Source
+
+    func handlePowerSourceChanged(_ isOnBattery: Bool) async {
+        await sendTrackingAction(.powerSourceChanged(isOnBattery: isOnBattery))
     }
 
     // MARK: - Display Configuration

--- a/Sources/AppDelegate/AppDelegate+Persistence.swift
+++ b/Sources/AppDelegate/AppDelegate+Persistence.swift
@@ -18,6 +18,7 @@ extension AppDelegate {
         defaults.set(blurWhenAway, forKey: SettingsKeys.blurWhenAway)
         defaults.set(showInDock, forKey: SettingsKeys.showInDock)
         defaults.set(pauseOnTheGo, forKey: SettingsKeys.pauseOnTheGo)
+        defaults.set(pauseOnBattery, forKey: SettingsKeys.pauseOnBattery)
         defaults.set(useFullScreenOverlay, forKey: SettingsKeys.useFullScreenOverlay)
         defaults.set(toggleShortcutEnabled, forKey: SettingsKeys.toggleShortcutEnabled)
         defaults.set(Int(toggleShortcut.keyCode), forKey: SettingsKeys.toggleShortcutKeyCode)
@@ -45,6 +46,9 @@ extension AppDelegate {
         blurWhenAway = defaults.bool(forKey: SettingsKeys.blurWhenAway)
         showInDock = defaults.bool(forKey: SettingsKeys.showInDock)
         pauseOnTheGo = defaults.bool(forKey: SettingsKeys.pauseOnTheGo)
+        if defaults.object(forKey: SettingsKeys.pauseOnBattery) != nil {
+            applyTrackingAction(.setPauseOnBatteryEnabled(defaults.bool(forKey: SettingsKeys.pauseOnBattery)))
+        }
         useFullScreenOverlay = defaults.bool(forKey: SettingsKeys.useFullScreenOverlay)
         cameraDetector.selectedCameraID = defaults.string(forKey: SettingsKeys.lastCameraID)
         if let sourceString = defaults.string(forKey: SettingsKeys.trackingSource),

--- a/Sources/AppDelegate/AppDelegate+Tracking.swift
+++ b/Sources/AppDelegate/AppDelegate+Tracking.swift
@@ -225,6 +225,10 @@ extension AppDelegate {
                 cameraProfile: context.profile
             )
         )
+
+        // Seed the current power source so launching on battery honors
+        // pause-on-battery without waiting for the first power transition.
+        await sendTrackingAction(.powerSourceChanged(isOnBattery: powerSourceObserver.isOnBattery))
     }
 
     private func makeInitialSetupContext() -> InitialSetupContext {
@@ -303,6 +307,11 @@ extension AppDelegate {
         pauseOnTheGo = isEnabled
         saveSettings()
         await sendTrackingAction(.pauseOnTheGoSettingChanged(isEnabled: isEnabled))
+    }
+
+    func setPauseOnBatteryEnabled(_ isEnabled: Bool) async {
+        await sendTrackingAction(.setPauseOnBatteryEnabled(isEnabled))
+        saveSettings()
     }
 
     // MARK: - Monitoring

--- a/Sources/AppDelegate/AppDelegate.swift
+++ b/Sources/AppDelegate/AppDelegate.swift
@@ -112,6 +112,9 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     }
     var showInDock = false
     var pauseOnTheGo = false
+    var pauseOnBattery: Bool {
+        trackingStore.withState { $0.pauseOnBatteryEnabled }
+    }
     var useFullScreenOverlay = false
     var settingsWindowController = SettingsWindowController()
     var supportWindowController = SupportWindowController()
@@ -122,6 +125,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     let displayMonitor = DisplayMonitor()
     let cameraObserver = CameraObserver()
     let screenLockObserver = ScreenLockObserver()
+    let powerSourceObserver = PowerSourceObserver()
     let hotkeyManager = HotkeyManager()
 
     lazy var trackingStore: StoreOf<TrackingFeature> = {
@@ -444,6 +448,14 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
         screenLockObserver.startObserving()
+
+        // AC/battery power source
+        powerSourceObserver.onPowerSourceChanged = { [weak self] isOnBattery in
+            Task { @MainActor in
+                await self?.handlePowerSourceChanged(isOnBattery)
+            }
+        }
+        powerSourceObserver.startObserving()
 
         // Global hotkey
         hotkeyManager.configure(

--- a/Sources/Core/AppState.swift
+++ b/Sources/Core/AppState.swift
@@ -8,6 +8,7 @@ enum PauseReason: Equatable {
     case cameraDisconnected
     case screenLocked
     case airPodsRemoved
+    case onBattery
 }
 
 // MARK: - App State

--- a/Sources/Core/PostureEngine.swift
+++ b/Sources/Core/PostureEngine.swift
@@ -66,6 +66,12 @@ struct AirPodsConnectionTransitionResult: Equatable {
     let shouldRestartMonitoring: Bool
 }
 
+/// Result of a power source change or pause-on-battery setting change
+struct PowerSourceTransitionResult: Equatable {
+    let newState: AppState
+    let shouldRestartMonitoring: Bool
+}
+
 /// Result of camera-connect handling
 struct CameraConnectedTransitionResult: Equatable {
     let newState: AppState
@@ -447,9 +453,14 @@ struct PostureEngine {
     }
 
     /// Determine unlock behavior based on captured pre-lock state.
+    /// If tracking would resume while on battery with pause-on-battery enabled
+    /// (e.g. the Mac was unplugged while the lid was closed), land in the
+    /// battery pause instead of restarting.
     static func stateWhenScreenUnlocks(
         currentState: AppState,
-        stateBeforeLock: AppState?
+        stateBeforeLock: AppState?,
+        pauseOnBatteryEnabled: Bool = false,
+        isOnBattery: Bool = false
     ) -> ScreenUnlockTransitionResult {
         guard case .paused(.screenLocked) = currentState else {
             return ScreenUnlockTransitionResult(
@@ -467,11 +478,66 @@ struct PostureEngine {
             )
         }
 
+        if pauseOnBatteryEnabled, isOnBattery, shouldPauseOnBattery(from: previousState) {
+            return ScreenUnlockTransitionResult(
+                newState: .paused(.onBattery),
+                stateBeforeLock: nil,
+                shouldRestartMonitoring: false
+            )
+        }
+
         return ScreenUnlockTransitionResult(
             newState: previousState,
             stateBeforeLock: nil,
             shouldRestartMonitoring: previousState == .monitoring
         )
+    }
+
+    // MARK: - Power Source Transitions
+
+    /// States the battery pause replaces: monitoring, plus the AirPods-removed
+    /// pause whose detector keeps running to watch for re-insertion. Calibration
+    /// is left alone — the user is actively mid-flow.
+    private static func shouldPauseOnBattery(from state: AppState) -> Bool {
+        state == .monitoring || state == .paused(.airPodsRemoved)
+    }
+
+    /// Determine state impact of an AC/battery power source change.
+    static func stateWhenPowerSourceChanges(
+        currentState: AppState,
+        isOnBattery: Bool,
+        pauseOnBatteryEnabled: Bool
+    ) -> PowerSourceTransitionResult {
+        if isOnBattery {
+            guard pauseOnBatteryEnabled, shouldPauseOnBattery(from: currentState) else {
+                return PowerSourceTransitionResult(newState: currentState, shouldRestartMonitoring: false)
+            }
+            return PowerSourceTransitionResult(newState: .paused(.onBattery), shouldRestartMonitoring: false)
+        }
+
+        guard currentState == .paused(.onBattery) else {
+            return PowerSourceTransitionResult(newState: currentState, shouldRestartMonitoring: false)
+        }
+        return PowerSourceTransitionResult(newState: .monitoring, shouldRestartMonitoring: true)
+    }
+
+    /// Determine state impact when the pause-on-battery setting changes.
+    static func stateWhenPauseOnBatterySettingChanges(
+        currentState: AppState,
+        isEnabled: Bool,
+        isOnBattery: Bool
+    ) -> PowerSourceTransitionResult {
+        if isEnabled {
+            guard isOnBattery, shouldPauseOnBattery(from: currentState) else {
+                return PowerSourceTransitionResult(newState: currentState, shouldRestartMonitoring: false)
+            }
+            return PowerSourceTransitionResult(newState: .paused(.onBattery), shouldRestartMonitoring: false)
+        }
+
+        guard currentState == .paused(.onBattery) else {
+            return PowerSourceTransitionResult(newState: currentState, shouldRestartMonitoring: false)
+        }
+        return PowerSourceTransitionResult(newState: .monitoring, shouldRestartMonitoring: true)
     }
 
     /// Determine state impact of an AirPods in-ear connection change.
@@ -505,7 +571,8 @@ struct PostureEngine {
             return CameraConnectedTransitionResult(newState: currentState, shouldSelectAndStartMonitoring: false)
         }
 
-        guard case .paused(let reason) = currentState else {
+        // The battery pause is only lifted by AC power, the setting, or the user.
+        guard case .paused(let reason) = currentState, reason != .onBattery else {
             return CameraConnectedTransitionResult(newState: currentState, shouldSelectAndStartMonitoring: false)
         }
 
@@ -528,7 +595,7 @@ struct PostureEngine {
         hasFallbackCamera: Bool,
         fallbackMatchesProfile: Bool
     ) -> CameraDisconnectedTransitionResult {
-        guard trackingSource == .camera else {
+        guard trackingSource == .camera, currentState != .paused(.onBattery) else {
             return CameraDisconnectedTransitionResult(newState: currentState, action: .none)
         }
 
@@ -563,7 +630,7 @@ struct PostureEngine {
         hasMatchingProfileCamera: Bool,
         selectedCameraMatchesProfile: Bool
     ) -> DisplayConfigurationTransitionResult {
-        guard currentState != .disabled else {
+        guard currentState != .disabled, currentState != .paused(.onBattery) else {
             return DisplayConfigurationTransitionResult(
                 newState: currentState,
                 shouldSwitchToProfileCamera: false,

--- a/Sources/Core/PostureUIState.swift
+++ b/Sources/Core/PostureUIState.swift
@@ -102,6 +102,8 @@ struct PostureUIState: Equatable {
             return L("status.pausedScreenLocked")
         case .airPodsRemoved:
             return L("status.pausedPutInAirPods")
+        case .onBattery:
+            return L("status.pausedOnBattery")
         }
     }
 }

--- a/Sources/Core/TrackingFeature.swift
+++ b/Sources/Core/TrackingFeature.swift
@@ -55,6 +55,8 @@ struct TrackingFeature: Reducer {
         var monitoringState = PostureMonitoringState()
         var postureConfig = PostureConfig()
         var lastPostureReadingTime: Date?
+        var pauseOnBatteryEnabled: Bool = false
+        var isOnBattery: Bool = false
 
         init(
             appState: AppState = .disabled,
@@ -68,7 +70,9 @@ struct TrackingFeature: Reducer {
             stateBeforeLock: AppState? = nil,
             monitoringState: PostureMonitoringState = PostureMonitoringState(),
             postureConfig: PostureConfig = PostureConfig(),
-            lastPostureReadingTime: Date? = nil
+            lastPostureReadingTime: Date? = nil,
+            pauseOnBatteryEnabled: Bool = false,
+            isOnBattery: Bool = false
         ) {
             self.appState = appState
             self.trackingMode = trackingMode
@@ -82,6 +86,8 @@ struct TrackingFeature: Reducer {
             self.monitoringState = monitoringState
             self.postureConfig = postureConfig
             self.lastPostureReadingTime = lastPostureReadingTime
+            self.pauseOnBatteryEnabled = pauseOnBatteryEnabled
+            self.isOnBattery = isOnBattery
         }
 
         func readiness(for source: TrackingSource) -> TrackingSourceReadiness {
@@ -148,6 +154,8 @@ struct TrackingFeature: Reducer {
         case calibrationCompleted(source: TrackingSource)
         case screenLocked
         case screenUnlocked
+        case powerSourceChanged(isOnBattery: Bool)
+        case setPauseOnBatteryEnabled(Bool)
         case displayConfigurationChanged(
             pauseOnTheGoEnabled: Bool,
             isLaptopOnlyConfiguration: Bool,
@@ -502,10 +510,38 @@ struct TrackingFeature: Reducer {
             case .screenUnlocked:
                 let result = PostureEngine.stateWhenScreenUnlocks(
                     currentState: state.appState,
-                    stateBeforeLock: state.stateBeforeLock
+                    stateBeforeLock: state.stateBeforeLock,
+                    pauseOnBatteryEnabled: state.pauseOnBatteryEnabled,
+                    isOnBattery: state.isOnBattery
                 )
                 state.appState = result.newState
                 state.stateBeforeLock = result.stateBeforeLock
+                if result.shouldRestartMonitoring {
+                    return finish(perform(.startMonitoring))
+                }
+                return finish()
+
+            case .powerSourceChanged(let isOnBattery):
+                state.isOnBattery = isOnBattery
+                let result = PostureEngine.stateWhenPowerSourceChanges(
+                    currentState: state.appState,
+                    isOnBattery: isOnBattery,
+                    pauseOnBatteryEnabled: state.pauseOnBatteryEnabled
+                )
+                state.appState = result.newState
+                if result.shouldRestartMonitoring {
+                    return finish(perform(.startMonitoring))
+                }
+                return finish()
+
+            case .setPauseOnBatteryEnabled(let isEnabled):
+                state.pauseOnBatteryEnabled = isEnabled
+                let result = PostureEngine.stateWhenPauseOnBatterySettingChanges(
+                    currentState: state.appState,
+                    isEnabled: isEnabled,
+                    isOnBattery: state.isOnBattery
+                )
+                state.appState = result.newState
                 if result.shouldRestartMonitoring {
                     return finish(perform(.startMonitoring))
                 }
@@ -588,6 +624,10 @@ struct TrackingFeature: Reducer {
     // MARK: - Automatic Mode Source Resolution
 
     private func resolveAutomaticSource(_ state: inout State) -> Effect<Action> {
+        // The battery pause is sticky: source readiness changes must not resume
+        // tracking. AC power, the setting, or a direct user action lifts it.
+        guard state.appState != .paused(.onBattery) else { return .none }
+
         let previousSource = state.activeSource
         let previousAppState = state.appState
         let prefReadiness = state.readiness(for: state.preferredSource)

--- a/Sources/Resources/de.lproj/Localizable.strings
+++ b/Sources/Resources/de.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "status.airPodsDisconnected" = "Status: AirPods getrennt";
 "status.pausedScreenLocked" = "Status: Pausiert (Bildschirm gesperrt)";
 "status.pausedPutInAirPods" = "Status: Pausiert (AirPods einsetzen)";
+"status.pausedOnBattery" = "Status: Pausiert (Akkubetrieb)";
 
 // MARK: - Menu Bar Icon Accessibility (Models.swift)
 
@@ -154,6 +155,8 @@
 "settings.blurWhenAway.help.airpods" = "Volle Unschärfe anwenden, wenn Sie sich entfernen. Nur verfügbar bei Kamera-Erkennung.";
 "settings.pauseOnTheGo" = "Unterwegs pausieren";
 "settings.pauseOnTheGo.help" = "Automatisch pausieren bei reinem Laptop-Display";
+"settings.pauseOnBattery" = "Im Akkubetrieb pausieren";
+"settings.pauseOnBattery.help" = "Automatisch pausieren, um im Akkubetrieb Strom zu sparen";
 "settings.fullScreenOverlay" = "Vollbild-Overlay";
 "settings.fullScreenOverlay.help" = "Effekte auf Dock und Menüleiste ausdehnen";
 "settings.shortcut" = "Tastenkürzel";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "status.airPodsDisconnected" = "Status: AirPods disconnected";
 "status.pausedScreenLocked" = "Status: Paused (screen locked)";
 "status.pausedPutInAirPods" = "Status: Paused (put in AirPods)";
+"status.pausedOnBattery" = "Status: Paused (on battery)";
 
 // MARK: - Menu Bar Icon Accessibility (Models.swift)
 
@@ -154,6 +155,8 @@
 "settings.blurWhenAway.help.airpods" = "Apply full blur when you step away. Only available when using camera for detection.";
 "settings.pauseOnTheGo" = "Pause on the go";
 "settings.pauseOnTheGo.help" = "Auto-pause on laptop-only display";
+"settings.pauseOnBattery" = "Pause on battery";
+"settings.pauseOnBattery.help" = "Auto-pause to save power when on battery";
 "settings.fullScreenOverlay" = "Full screen overlay";
 "settings.fullScreenOverlay.help" = "Extend effects over the dock and menu bar";
 "settings.shortcut" = "Shortcut";

--- a/Sources/Resources/es.lproj/Localizable.strings
+++ b/Sources/Resources/es.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "status.airPodsDisconnected" = "Estado: AirPods desconectados";
 "status.pausedScreenLocked" = "Estado: Pausado (pantalla bloqueada)";
 "status.pausedPutInAirPods" = "Estado: Pausado (ponte los AirPods)";
+"status.pausedOnBattery" = "Estado: Pausado (con batería)";
 
 // MARK: - Menu Bar Icon Accessibility (Models.swift)
 
@@ -154,6 +155,8 @@
 "settings.blurWhenAway.help.airpods" = "Aplicar desenfoque completo cuando te ausentes. Solo disponible cuando se usa la cámara para la detección.";
 "settings.pauseOnTheGo" = "Pausar en movimiento";
 "settings.pauseOnTheGo.help" = "Pausar automáticamente con pantalla de portátil";
+"settings.pauseOnBattery" = "Pausar con batería";
+"settings.pauseOnBattery.help" = "Pausar automáticamente para ahorrar energía con batería";
 "settings.fullScreenOverlay" = "Superposición a pantalla completa";
 "settings.fullScreenOverlay.help" = "Extender efectos sobre el Dock y la barra de menús";
 "settings.shortcut" = "Atajo";

--- a/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Resources/fr.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "status.airPodsDisconnected" = "État : AirPods déconnectés";
 "status.pausedScreenLocked" = "État : En pause (écran verrouillé)";
 "status.pausedPutInAirPods" = "État : En pause (mettez vos AirPods)";
+"status.pausedOnBattery" = "État : En pause (sur batterie)";
 
 // MARK: - Menu Bar Icon Accessibility (Models.swift)
 
@@ -154,6 +155,8 @@
 "settings.blurWhenAway.help.airpods" = "Applique un flou complet lorsque vous vous absentez. Disponible uniquement avec la détection par caméra.";
 "settings.pauseOnTheGo" = "Pause en déplacement";
 "settings.pauseOnTheGo.help" = "Pause automatique sur écran du portable uniquement";
+"settings.pauseOnBattery" = "Pause sur batterie";
+"settings.pauseOnBattery.help" = "Pause automatique pour économiser l'énergie sur batterie";
 "settings.fullScreenOverlay" = "Superposition plein écran";
 "settings.fullScreenOverlay.help" = "Étendre les effets sur le Dock et la barre des menus";
 "settings.shortcut" = "Raccourci";

--- a/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Resources/ja.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "status.airPodsDisconnected" = "状態: AirPods 未接続";
 "status.pausedScreenLocked" = "状態: 一時停止 (画面ロック中)";
 "status.pausedPutInAirPods" = "状態: 一時停止 (AirPods を装着してください)";
+"status.pausedOnBattery" = "状態: 一時停止 (バッテリー駆動中)";
 
 // MARK: - Menu Bar Icon Accessibility (Models.swift)
 
@@ -154,6 +155,8 @@
 "settings.blurWhenAway.help.airpods" = "離席時に完全なぼかしを適用。カメラでの検出時のみ利用可能です。";
 "settings.pauseOnTheGo" = "移動中は一時停止";
 "settings.pauseOnTheGo.help" = "ノートパソコンのディスプレイのみの場合に自動一時停止";
+"settings.pauseOnBattery" = "バッテリー駆動中は一時停止";
+"settings.pauseOnBattery.help" = "バッテリー駆動中は自動的に一時停止して電力を節約";
 "settings.fullScreenOverlay" = "全画面オーバーレイ";
 "settings.fullScreenOverlay.help" = "Dockとメニューバーにも効果を広げる";
 "settings.shortcut" = "ショートカット";

--- a/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 "status.airPodsDisconnected" = "状态：AirPods 已断开";
 "status.pausedScreenLocked" = "状态：已暂停（屏幕已锁定）";
 "status.pausedPutInAirPods" = "状态：已暂停（请佩戴 AirPods）";
+"status.pausedOnBattery" = "状态：已暂停（电池供电）";
 
 // MARK: - Menu Bar Icon Accessibility (Models.swift)
 
@@ -154,6 +155,8 @@
 "settings.blurWhenAway.help.airpods" = "离开时应用完全模糊。仅在使用摄像头检测时可用。";
 "settings.pauseOnTheGo" = "移动中暂停";
 "settings.pauseOnTheGo.help" = "仅使用笔记本显示屏时自动暂停";
+"settings.pauseOnBattery" = "电池供电时暂停";
+"settings.pauseOnBattery.help" = "使用电池时自动暂停以省电";
 "settings.fullScreenOverlay" = "全屏覆盖";
 "settings.fullScreenOverlay.help" = "将效果延伸至程序坞和菜单栏";
 "settings.shortcut" = "快捷键";

--- a/Sources/Settings/SettingsKeys.swift
+++ b/Sources/Settings/SettingsKeys.swift
@@ -9,6 +9,7 @@ enum SettingsKeys {
     static let blurWhenAway = "blurWhenAway"
     static let showInDock = "showInDock"
     static let pauseOnTheGo = "pauseOnTheGo"
+    static let pauseOnBattery = "pauseOnBattery"
     static let useFullScreenOverlay = "useFullScreenOverlay"
     static let lastCameraID = "lastCameraID"
     static let profiles = "profiles"

--- a/Sources/System/PowerSourceObserver.swift
+++ b/Sources/System/PowerSourceObserver.swift
@@ -1,0 +1,77 @@
+import Foundation
+import IOKit.ps
+
+/// Observes AC/battery power source changes via IOKit power sources
+final class PowerSourceObserver {
+
+    private var runLoopSource: CFRunLoopSource?
+    private var lastKnownIsOnBattery: Bool?
+
+    /// Fired on actual AC<->battery transitions. IOKit also notifies for
+    /// battery capacity ticks; those are deduplicated in `evaluatePowerSource`.
+    var onPowerSourceChanged: ((_ isOnBattery: Bool) -> Void)?
+
+    /// Reads the current power source; replaceable so tests can simulate
+    /// transitions without real power events.
+    var currentPowerSourceProvider: () -> Bool = PowerSourceObserver.systemIsOnBattery
+
+    var isObserving: Bool {
+        runLoopSource != nil
+    }
+
+    /// Whether the Mac is currently drawing from its battery.
+    var isOnBattery: Bool {
+        currentPowerSourceProvider()
+    }
+
+    // MARK: - Public API
+
+    func startObserving() {
+        guard !isObserving else { return }
+
+        lastKnownIsOnBattery = isOnBattery
+
+        let context = Unmanaged.passUnretained(self).toOpaque()
+        let callback: IOPowerSourceCallbackType = { context in
+            guard let context else { return }
+            let observer = Unmanaged<PowerSourceObserver>.fromOpaque(context).takeUnretainedValue()
+            observer.evaluatePowerSource()
+        }
+
+        guard let source = IOPSNotificationCreateRunLoopSource(callback, context)?.takeRetainedValue() else {
+            return
+        }
+
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .defaultMode)
+    }
+
+    func stopObserving() {
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .defaultMode)
+            runLoopSource = nil
+        }
+        lastKnownIsOnBattery = nil
+    }
+
+    /// Re-reads the power source and fires the callback only on a real change.
+    func evaluatePowerSource() {
+        let isOnBattery = self.isOnBattery
+        guard isOnBattery != lastKnownIsOnBattery else { return }
+        lastKnownIsOnBattery = isOnBattery
+        onPowerSourceChanged?(isOnBattery)
+    }
+
+    private static func systemIsOnBattery() -> Bool {
+        let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue()
+        guard let snapshot,
+              let sourceType = IOPSGetProvidingPowerSourceType(snapshot)?.takeUnretainedValue() as String? else {
+            return false
+        }
+        return sourceType == kIOPMBatteryPowerKey
+    }
+
+    deinit {
+        stopObserving()
+    }
+}

--- a/Sources/UI/SettingsWindow.swift
+++ b/Sources/UI/SettingsWindow.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @State private var blurWhenAway: Bool
     @State private var showInDock: Bool
     @State private var pauseOnTheGo: Bool
+    @State private var pauseOnBattery: Bool
     @State private var useCompatibilityMode: Bool
     @State private var useFullScreenOverlay: Bool
     @State private var selectedCameraID: String
@@ -82,6 +83,7 @@ struct SettingsView: View {
         _blurWhenAway = State(initialValue: appDelegate.blurWhenAway)
         _showInDock = State(initialValue: appDelegate.showInDock)
         _pauseOnTheGo = State(initialValue: appDelegate.pauseOnTheGo)
+        _pauseOnBattery = State(initialValue: appDelegate.pauseOnBattery)
         _useCompatibilityMode = State(initialValue: appDelegate.useCompatibilityMode)
         _useFullScreenOverlay = State(initialValue: appDelegate.useFullScreenOverlay)
         _selectedCameraID = State(initialValue: appDelegate.selectedCameraID ?? cameras.first?.uniqueID ?? "")
@@ -564,8 +566,17 @@ struct SettingsView: View {
                         appDelegate.rebuildOverlayWindows()
                     }
 
-                    Spacer()
-                        .frame(maxWidth: .infinity)
+                    CompactToggle(
+                        title: L("settings.pauseOnBattery"),
+                        helpText: L("settings.pauseOnBattery.help"),
+                        isOn: $pauseOnBattery
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .onChange(of: pauseOnBattery) { newValue in
+                        Task { @MainActor in
+                            await appDelegate.setPauseOnBatteryEnabled(newValue)
+                        }
+                    }
                 }
 
                 // Shortcut row

--- a/Tests/ObserverTests.swift
+++ b/Tests/ObserverTests.swift
@@ -248,3 +248,94 @@ final class CameraObserverTests: XCTestCase {
         XCTAssertTrue(observer.isObserving, "Should be able to restart after stopping")
     }
 }
+
+// MARK: - PowerSourceObserver Tests
+
+final class PowerSourceObserverTests: XCTestCase {
+
+    private var observer: PowerSourceObserver!
+
+    override func setUp() {
+        super.setUp()
+        observer = PowerSourceObserver()
+    }
+
+    override func tearDown() {
+        observer = nil
+        super.tearDown()
+    }
+
+    func testIsObservingIsFalseInitially() {
+        XCTAssertFalse(observer.isObserving)
+    }
+
+    func testStartObservingSetsIsObservingTrue() {
+        observer.startObserving()
+        XCTAssertTrue(observer.isObserving)
+    }
+
+    func testStopObservingSetsIsObservingFalse() {
+        observer.startObserving()
+        observer.stopObserving()
+        XCTAssertFalse(observer.isObserving)
+    }
+
+    func testStartObservingIsIdempotent() {
+        observer.startObserving()
+        observer.startObserving()
+
+        XCTAssertTrue(observer.isObserving, "Should still be observing after double start")
+
+        observer.stopObserving()
+        XCTAssertFalse(observer.isObserving)
+    }
+
+    func testStopObservingIsIdempotent() {
+        observer.startObserving()
+        observer.stopObserving()
+        observer.stopObserving()
+
+        XCTAssertFalse(observer.isObserving)
+    }
+
+    func testIsOnBatteryReflectsProvider() {
+        observer.currentPowerSourceProvider = { true }
+        XCTAssertTrue(observer.isOnBattery)
+
+        observer.currentPowerSourceProvider = { false }
+        XCTAssertFalse(observer.isOnBattery)
+    }
+
+    func testEvaluateFiresCallbackOnlyOnTransitions() {
+        var isOnBattery = false
+        observer.currentPowerSourceProvider = { isOnBattery }
+
+        var received: [Bool] = []
+        observer.onPowerSourceChanged = { received.append($0) }
+
+        observer.startObserving()
+
+        // Capacity-tick style notifications with no source change stay silent
+        observer.evaluatePowerSource()
+        observer.evaluatePowerSource()
+        XCTAssertEqual(received, [])
+
+        isOnBattery = true
+        observer.evaluatePowerSource()
+        observer.evaluatePowerSource()
+        XCTAssertEqual(received, [true], "Repeated battery notifications should fire once")
+
+        isOnBattery = false
+        observer.evaluatePowerSource()
+        XCTAssertEqual(received, [true, false])
+    }
+
+    func testDeinitStopsObserving() {
+        var obs: PowerSourceObserver? = PowerSourceObserver()
+        obs?.startObserving()
+        XCTAssertTrue(obs?.isObserving == true)
+
+        obs = nil
+        // No crash or leak — deinit calls stopObserving
+    }
+}

--- a/Tests/PostureEngineTransitionTests.swift
+++ b/Tests/PostureEngineTransitionTests.swift
@@ -691,4 +691,229 @@ final class PostureEngineTransitionTests: XCTestCase {
         XCTAssertFalse(result.didSwitchSource)
         XCTAssertFalse(result.shouldStartMonitoring)
     }
+
+    // MARK: - Power Source Transitions
+
+    func testStateWhenPowerSwitchesToBatteryPausesMonitoring() {
+        let result = PostureEngine.stateWhenPowerSourceChanges(
+            currentState: .monitoring,
+            isOnBattery: true,
+            pauseOnBatteryEnabled: true
+        )
+
+        XCTAssertEqual(result.newState, .paused(.onBattery))
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    func testStateWhenPowerSwitchesToBatteryPausesAirPodsRemovedPause() {
+        // The AirPods-removed pause keeps its detector running, so the battery
+        // pause replaces it to actually save power.
+        let result = PostureEngine.stateWhenPowerSourceChanges(
+            currentState: .paused(.airPodsRemoved),
+            isOnBattery: true,
+            pauseOnBatteryEnabled: true
+        )
+
+        XCTAssertEqual(result.newState, .paused(.onBattery))
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    func testStateWhenPowerSwitchesToBatteryWithSettingDisabledIsNoOp() {
+        let result = PostureEngine.stateWhenPowerSourceChanges(
+            currentState: .monitoring,
+            isOnBattery: true,
+            pauseOnBatteryEnabled: false
+        )
+
+        XCTAssertEqual(result.newState, .monitoring)
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    func testStateWhenPowerSwitchesToBatteryLeavesCalibrationRunning() {
+        let result = PostureEngine.stateWhenPowerSourceChanges(
+            currentState: .calibrating,
+            isOnBattery: true,
+            pauseOnBatteryEnabled: true
+        )
+
+        XCTAssertEqual(result.newState, .calibrating)
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    func testStateWhenPowerSwitchesToBatteryLeavesDisabledAlone() {
+        let result = PostureEngine.stateWhenPowerSourceChanges(
+            currentState: .disabled,
+            isOnBattery: true,
+            pauseOnBatteryEnabled: true
+        )
+
+        XCTAssertEqual(result.newState, .disabled)
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    func testStateWhenPowerReturnsToACResumesFromBatteryPause() {
+        let result = PostureEngine.stateWhenPowerSourceChanges(
+            currentState: .paused(.onBattery),
+            isOnBattery: false,
+            pauseOnBatteryEnabled: true
+        )
+
+        XCTAssertEqual(result.newState, .monitoring)
+        XCTAssertTrue(result.shouldRestartMonitoring)
+    }
+
+    func testStateWhenPowerReturnsToACLeavesOtherPausesAlone() {
+        let result = PostureEngine.stateWhenPowerSourceChanges(
+            currentState: .paused(.screenLocked),
+            isOnBattery: false,
+            pauseOnBatteryEnabled: true
+        )
+
+        XCTAssertEqual(result.newState, .paused(.screenLocked))
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    func testEnablingPauseOnBatteryWhileOnBatteryPausesImmediately() {
+        let result = PostureEngine.stateWhenPauseOnBatterySettingChanges(
+            currentState: .monitoring,
+            isEnabled: true,
+            isOnBattery: true
+        )
+
+        XCTAssertEqual(result.newState, .paused(.onBattery))
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    func testEnablingPauseOnBatteryWhileOnACIsNoOp() {
+        let result = PostureEngine.stateWhenPauseOnBatterySettingChanges(
+            currentState: .monitoring,
+            isEnabled: true,
+            isOnBattery: false
+        )
+
+        XCTAssertEqual(result.newState, .monitoring)
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    func testDisablingPauseOnBatteryResumesFromBatteryPause() {
+        let result = PostureEngine.stateWhenPauseOnBatterySettingChanges(
+            currentState: .paused(.onBattery),
+            isEnabled: false,
+            isOnBattery: true
+        )
+
+        XCTAssertEqual(result.newState, .monitoring)
+        XCTAssertTrue(result.shouldRestartMonitoring)
+    }
+
+    func testDisablingPauseOnBatteryLeavesOtherStatesAlone() {
+        let result = PostureEngine.stateWhenPauseOnBatterySettingChanges(
+            currentState: .paused(.noProfile),
+            isEnabled: false,
+            isOnBattery: true
+        )
+
+        XCTAssertEqual(result.newState, .paused(.noProfile))
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    func testStateWhenScreenUnlocksOnBatteryLandsInBatteryPause() {
+        let result = PostureEngine.stateWhenScreenUnlocks(
+            currentState: .paused(.screenLocked),
+            stateBeforeLock: .monitoring,
+            pauseOnBatteryEnabled: true,
+            isOnBattery: true
+        )
+
+        XCTAssertEqual(result.newState, .paused(.onBattery))
+        XCTAssertNil(result.stateBeforeLock)
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    func testStateWhenScreenUnlocksOnACRestoresMonitoringDespiteSetting() {
+        let result = PostureEngine.stateWhenScreenUnlocks(
+            currentState: .paused(.screenLocked),
+            stateBeforeLock: .monitoring,
+            pauseOnBatteryEnabled: true,
+            isOnBattery: false
+        )
+
+        XCTAssertEqual(result.newState, .monitoring)
+        XCTAssertNil(result.stateBeforeLock)
+        XCTAssertTrue(result.shouldRestartMonitoring)
+    }
+
+    func testStateWhenScreenUnlocksOnBatteryWithSettingDisabledRestoresMonitoring() {
+        let result = PostureEngine.stateWhenScreenUnlocks(
+            currentState: .paused(.screenLocked),
+            stateBeforeLock: .monitoring,
+            pauseOnBatteryEnabled: false,
+            isOnBattery: true
+        )
+
+        XCTAssertEqual(result.newState, .monitoring)
+        XCTAssertNil(result.stateBeforeLock)
+        XCTAssertTrue(result.shouldRestartMonitoring)
+    }
+
+    func testStateWhenScreenUnlocksOnBatteryRestoresCalibrating() {
+        // Calibration is user-driven; the battery pause never replaces it.
+        let result = PostureEngine.stateWhenScreenUnlocks(
+            currentState: .paused(.screenLocked),
+            stateBeforeLock: .calibrating,
+            pauseOnBatteryEnabled: true,
+            isOnBattery: true
+        )
+
+        XCTAssertEqual(result.newState, .calibrating)
+        XCTAssertNil(result.stateBeforeLock)
+        XCTAssertFalse(result.shouldRestartMonitoring)
+    }
+
+    // MARK: - Battery Pause Stickiness
+
+    func testCameraConnectDoesNotLiftBatteryPause() {
+        let result = PostureEngine.stateWhenCameraConnects(
+            currentState: .paused(.onBattery),
+            trackingSource: .camera,
+            hasMatchingProfileForConnectedCamera: true
+        )
+
+        XCTAssertEqual(result.newState, .paused(.onBattery))
+        XCTAssertFalse(result.shouldSelectAndStartMonitoring)
+    }
+
+    func testCameraDisconnectDoesNotLiftBatteryPause() {
+        let result = PostureEngine.stateWhenCameraDisconnects(
+            currentState: .paused(.onBattery),
+            trackingSource: .camera,
+            disconnectedCameraIsSelected: true,
+            hasFallbackCamera: true,
+            fallbackMatchesProfile: true
+        )
+
+        XCTAssertEqual(result.newState, .paused(.onBattery))
+        XCTAssertEqual(result.action, .none)
+    }
+
+    func testDisplayConfigurationChangeDoesNotLiftBatteryPause() {
+        let result = PostureEngine.stateWhenDisplayConfigurationChanges(
+            currentState: .paused(.onBattery),
+            trackingSource: .camera,
+            pauseOnTheGoEnabled: false,
+            isLaptopOnlyConfiguration: false,
+            hasAnyCamera: true,
+            hasMatchingProfileCamera: true,
+            selectedCameraMatchesProfile: true
+        )
+
+        XCTAssertEqual(result.newState, .paused(.onBattery))
+        XCTAssertFalse(result.shouldSwitchToProfileCamera)
+        XCTAssertFalse(result.shouldStartMonitoring)
+    }
+
+    func testDetectorDoesNotRunWhilePausedOnBattery() {
+        XCTAssertFalse(PostureEngine.shouldDetectorRun(for: .paused(.onBattery), trackingSource: .camera))
+        XCTAssertFalse(PostureEngine.shouldDetectorRun(for: .paused(.onBattery), trackingSource: .airpods))
+    }
 }

--- a/Tests/PostureUIStateTests.swift
+++ b/Tests/PostureUIStateTests.swift
@@ -184,4 +184,17 @@ final class PostureUIStateTests: XCTestCase {
         XCTAssertEqual(uiState.statusText, L("status.pausedPutInAirPods"))
         XCTAssertEqual(uiState.icon, .paused)
     }
+
+    func testPausedOnBattery() {
+        let uiState = PostureUIState.derive(
+            from: .paused(.onBattery),
+            isCalibrated: true,
+            isCurrentlyAway: false,
+            isCurrentlySlouching: false,
+            trackingSource: .camera
+        )
+
+        XCTAssertEqual(uiState.statusText, L("status.pausedOnBattery"))
+        XCTAssertEqual(uiState.icon, .paused)
+    }
 }

--- a/Tests/TrackingFeatureTests.swift
+++ b/Tests/TrackingFeatureTests.swift
@@ -418,6 +418,159 @@ final class TrackingFeatureTests: XCTestCase {
         await assertIntents([.startMonitoring], recorder: recorder)
     }
 
+    // MARK: - Pause on Battery
+
+    @MainActor
+    func testPowerSourceChangesToBatteryPausesMonitoring() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                pauseOnBatteryEnabled: true
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.powerSourceChanged(isOnBattery: true)) {
+            $0.isOnBattery = true
+            $0.appState = .paused(.onBattery)
+        }
+        await store.finish()
+        await assertIntents([], recorder: recorder)
+    }
+
+    @MainActor
+    func testPowerSourceReturnsToACResumesMonitoring() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .paused(.onBattery),
+                pauseOnBatteryEnabled: true,
+                isOnBattery: true
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.powerSourceChanged(isOnBattery: false)) {
+            $0.isOnBattery = false
+            $0.appState = .monitoring
+        }
+        await store.finish()
+        await assertIntents([.startMonitoring], recorder: recorder)
+    }
+
+    @MainActor
+    func testPowerSourceChangeWithSettingDisabledOnlyRecordsBatteryState() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(appState: .monitoring),
+            recorder: recorder
+        )
+
+        await store.send(.powerSourceChanged(isOnBattery: true)) {
+            $0.isOnBattery = true
+        }
+        await store.finish()
+        await assertIntents([], recorder: recorder)
+    }
+
+    @MainActor
+    func testEnablingPauseOnBatteryWhileOnBatteryPauses() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                isOnBattery: true
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.setPauseOnBatteryEnabled(true)) {
+            $0.pauseOnBatteryEnabled = true
+            $0.appState = .paused(.onBattery)
+        }
+        await store.finish()
+        await assertIntents([], recorder: recorder)
+    }
+
+    @MainActor
+    func testDisablingPauseOnBatteryResumesMonitoring() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .paused(.onBattery),
+                pauseOnBatteryEnabled: true,
+                isOnBattery: true
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.setPauseOnBatteryEnabled(false)) {
+            $0.pauseOnBatteryEnabled = false
+            $0.appState = .monitoring
+        }
+        await store.finish()
+        await assertIntents([.startMonitoring], recorder: recorder)
+    }
+
+    @MainActor
+    func testScreenUnlockOnBatteryLandsInBatteryPause() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .monitoring,
+                pauseOnBatteryEnabled: true
+            ),
+            recorder: recorder
+        )
+
+        await store.send(.screenLocked) {
+            $0.appState = .paused(.screenLocked)
+            $0.stateBeforeLock = .monitoring
+        }
+
+        // Unplugged while the screen was locked (e.g. lid closed and moved)
+        await store.send(.powerSourceChanged(isOnBattery: true)) {
+            $0.isOnBattery = true
+        }
+
+        await store.send(.screenUnlocked) {
+            $0.appState = .paused(.onBattery)
+            $0.stateBeforeLock = nil
+        }
+        await store.finish()
+        await assertIntents([], recorder: recorder)
+    }
+
+    @MainActor
+    func testAutomaticModeReadinessChangeDoesNotLiftBatteryPause() async {
+        let recorder = EffectIntentRecorder()
+        let store = makeStore(
+            initialState: TrackingFeature.State(
+                appState: .paused(.onBattery),
+                trackingMode: .automatic,
+                manualSource: .camera,
+                preferredSource: .airpods,
+                autoReturnEnabled: true,
+                pauseOnBatteryEnabled: true,
+                isOnBattery: true
+            ),
+            recorder: recorder
+        )
+
+        let readiness = TrackingSourceReadiness(
+            permissionGranted: true,
+            connected: true,
+            calibrated: true,
+            available: true
+        )
+        await store.send(.sourceReadinessChanged(source: .airpods, readiness: readiness)) {
+            $0.airPodsReadiness = readiness
+        }
+        await store.finish()
+        await assertIntents([], recorder: recorder)
+    }
+
     @MainActor
     func testCameraDisconnectFallbackNoProfilePausesNoProfile() async {
         let recorder = EffectIntentRecorder()


### PR DESCRIPTION
Closes #90

## What

Adds a **Pause on battery** toggle (default off) that automatically pauses posture tracking while the Mac runs on battery power and resumes when AC power returns. Suggested by @MitchTalmadge in #90.

## How

- New `PowerSourceObserver` watches AC↔battery transitions via IOKit power-source notifications (public API, safe for both GitHub and App Store builds), deduplicating battery-percentage ticks.
- New `PauseReason.onBattery` flows through the existing TCA store and `PostureEngine` pure transitions; detectors fully stop while paused (that's the power saving), and resume goes through `startMonitoring` so calibration/connection are re-checked.
- Setting persists in `UserDefaults`, lives in the tracking store, and the toggle + menu bar status text are localized in all six languages.

## Edge cases covered

- **Lid closed → unplugged → reopened**: screen-unlock re-reads live power state, so unlock lands in the battery pause instead of resuming.
- **Launch on battery**: initial setup seeds the current power source so the app pauses right after startup.
- **Sticky pause**: camera hot-plug, display changes, and automatic-mode readiness events can't lift the pause — only AC power, the setting, or a direct user action can. Enabling the toggle while on battery pauses immediately; disabling resumes.
- Calibration is never interrupted, and the AirPods-removed pause (whose detector keeps running) is also replaced to actually save power.

## Testing

24 new tests across engine transitions, reducer behavior (including the lock/unplug/unlock sequence), observer dedupe, and status text. Full suite: 439 tests passing, headless. Verified live on battery: enabling the toggle pauses immediately, plugging in resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)