### PR TITLE
Add Sparkle auto-update for GitHub builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,10 @@
 When the user says "ship it", perform the complete release workflow:
 
 1. **Pull latest changes** with `git pull --rebase origin main` - ALWAYS do this first before committing
-2. **Bump version** in `build.sh`
+2. **Bump version** in `build.sh` (both `VERSION` and `BUILD_NUMBER`)
 3. **Commit** cleanup/feature changes with proper attribution
 4. **Merge** to main (if on a feature branch)
-5. **Run `./release.sh X.Y.Z`** - builds, signs, notarizes, creates GitHub release
+5. **Run `./release.sh X.Y.Z`** - builds, signs, notarizes, creates GitHub release, updates and pushes the Sparkle appcast
 6. **Update release notes** with user-friendly description via `gh release edit`
 7. **Update CHANGELOG.md** with new version entry
 8. **Update README.md** contributors section if applicable
@@ -130,6 +130,16 @@ After upload:
 4. Answer Export Compliance: "No" (no encryption)
 5. Save → Add for Review → Submit to App Review
 
+### Auto-Update (Sparkle)
+
+GitHub builds auto-update via Sparkle. App Store builds contain no trace of Sparkle (the `APP_STORE` flag compiles the code out and `-dead_strip_dylibs` removes the linkage) and update through the App Store itself.
+
+- **Feed**: `appcast.xml` at the repo root, served from raw.githubusercontent.com (`SPARKLE_FEED_URL` in `build.sh`). An update goes live when appcast.xml lands on main; release.sh step 8 edits, commits, and pushes it automatically.
+- **Update eligibility** is decided by comparing `BUILD_NUMBER` (CFBundleVersion), so `BUILD_NUMBER` must increase with every release, not just `VERSION`. release.sh aborts if `VERSION` in build.sh does not match the release argument.
+- **Signing**: updates are EdDSA-signed. The private key lives in the login Keychain as "Private key for signing Sparkle updates" (public key: `SPARKLE_PUBLIC_ED_KEY` in `build.sh`). If the key is lost, shipped apps will reject future updates, so keep a backup. release.sh signs Sparkle's nested components before the app, then signs the final ZIP with `sign_update`. Never hand-edit appcast signatures.
+- **ZIPs must be created with `ditto -c -k --keepParent`**: `zip -r` flattens Sparkle.framework's internal symlinks, which breaks the code signature and makes Sparkle reject the update.
+- Sparkle CLI tools ship with the SwiftPM artifact at `.build/artifacts/sparkle/Sparkle/bin/`.
+
 ## Build Configurations
 
 - `./build.sh --dev` - Fast iteration: debug config, host arch only (~10s warm). Use this during development. Not suitable for distribution — debug binary, non-universal.
@@ -182,7 +192,7 @@ pkill -x Dorso; ./build.sh --dev && rm -rf /Applications/Dorso.app && cp -r buil
 
 ## Version Bumping
 
-Update version in `build.sh` (VERSION variable) before releasing.
+Update both `VERSION` and `BUILD_NUMBER` in `build.sh` before releasing. Sparkle compares `BUILD_NUMBER` to decide whether an update is offered, so it must increase every release.
 
 ## Key Files
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    },
+    {
       "identity" : "swift-case-paths",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",

--- a/Package.swift
+++ b/Package.swift
@@ -11,14 +11,16 @@ let package = Package(
         .library(name: "DorsoCore", targets: ["DorsoCore"])
     ],
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.10.0")
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.10.0"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.4")
     ],
     targets: [
         // Core logic library - testable, no main entry point
         .target(
             name: "DorsoCore",
             dependencies: [
-                .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+                .product(name: "Sparkle", package: "Sparkle")
             ],
             path: "Sources",
             exclude: ["App", "Icons"],

--- a/Sources/AppDelegate/AppDelegate.swift
+++ b/Sources/AppDelegate/AppDelegate.swift
@@ -31,6 +31,13 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     // UI Components
     let menuBarManager = MenuBarManager()
 
+    #if !APP_STORE
+    /// Sparkle auto-updater. Created in applicationDidFinishLaunching (not
+    /// init) so headless tests constructing AppDelegate never start the
+    /// update machinery.
+    var updaterManager: UpdaterManager?
+    #endif
+
     // Overlay windows and blur
     var windows: [NSWindow] = []
     var blurViews: [NSVisualEffectView] = []
@@ -378,6 +385,10 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.applicationIconImage = applyMacOSIconMask(to: icon)
         }
 
+        #if !APP_STORE
+        updaterManager = UpdaterManager()
+        #endif
+
         setupDetectors()
         setupMenuBar()
         withAccessoryActivationPolicy {
@@ -505,6 +516,13 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.quit()
             }
         }
+        #if !APP_STORE
+        menuBarManager.onCheckForUpdates = { [weak self] in
+            Task { @MainActor in
+                self?.updaterManager?.checkForUpdates()
+            }
+        }
+        #endif
     }
 
     // MARK: - Menu Actions

--- a/Sources/Resources/de.lproj/Localizable.strings
+++ b/Sources/Resources/de.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "menu.analytics" = "Statistiken";
 "menu.settings" = "Einstellungen";
 "menu.quit" = "Beenden";
+"menu.checkForUpdates" = "Nach Updates suchen…";
 
 // MARK: - App Menu (DorsoMain.swift)
 
@@ -148,6 +149,8 @@
 "settings.detection.help" = "Balance zwischen Reaktionsfähigkeit und Akku. Reaktiv erkennt schnell, Leistung schont den Akku.";
 "settings.launchAtLogin" = "Beim Anmelden starten";
 "settings.launchAtLogin.help" = "Dorso automatisch beim Anmelden starten";
+"settings.autoUpdates" = "Automatische Updates";
+"settings.autoUpdates.help" = "Im Hintergrund nach neuen Versionen suchen und deren Installation anbieten";
 "settings.showInDock" = "Im Dock anzeigen";
 "settings.showInDock.help" = "Dorso im Dock und bei Cmd+Tab anzeigen";
 "settings.blurWhenAway" = "Bei Abwesenheit unscharf";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "menu.analytics" = "Analytics";
 "menu.settings" = "Settings";
 "menu.quit" = "Quit";
+"menu.checkForUpdates" = "Check for Updates…";
 
 // MARK: - App Menu (DorsoMain.swift)
 
@@ -148,6 +149,8 @@
 "settings.detection.help" = "Balance responsiveness vs battery. Responsive detects quickly, Performance saves battery.";
 "settings.launchAtLogin" = "Launch at login";
 "settings.launchAtLogin.help" = "Automatically start Dorso when you log in";
+"settings.autoUpdates" = "Automatic updates";
+"settings.autoUpdates.help" = "Check for new versions in the background and offer to install them";
 "settings.showInDock" = "Show in dock";
 "settings.showInDock.help" = "Keep Dorso in Dock and Cmd+Tab";
 "settings.blurWhenAway" = "Blur when away";

--- a/Sources/Resources/es.lproj/Localizable.strings
+++ b/Sources/Resources/es.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "menu.analytics" = "Estadísticas";
 "menu.settings" = "Ajustes";
 "menu.quit" = "Salir";
+"menu.checkForUpdates" = "Buscar actualizaciones…";
 
 // MARK: - App Menu (DorsoMain.swift)
 
@@ -148,6 +149,8 @@
 "settings.detection.help" = "Equilibrio entre capacidad de respuesta y duración de la batería. Reactiva detecta rápido, Rendimienta ahorra batería.";
 "settings.launchAtLogin" = "Iniciar al arrancar";
 "settings.launchAtLogin.help" = "Iniciar Dorso automáticamente al iniciar sesión";
+"settings.autoUpdates" = "Actualizaciones automáticas";
+"settings.autoUpdates.help" = "Buscar nuevas versiones en segundo plano y ofrecer instalarlas";
 "settings.showInDock" = "Mostrar en el dock";
 "settings.showInDock.help" = "Mantener Dorso en el Dock y Cmd+Tab";
 "settings.blurWhenAway" = "Desenfocar al ausentarse";

--- a/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Resources/fr.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "menu.analytics" = "Statistiques";
 "menu.settings" = "Réglages";
 "menu.quit" = "Quitter";
+"menu.checkForUpdates" = "Rechercher des mises à jour…";
 
 // MARK: - App Menu (DorsoMain.swift)
 
@@ -148,6 +149,8 @@
 "settings.detection.help" = "Équilibre entre réactivité et batterie. Réactif détecte rapidement, Performance économise la batterie.";
 "settings.launchAtLogin" = "Lancer au démarrage";
 "settings.launchAtLogin.help" = "Démarrer Dorso automatiquement à l'ouverture de session";
+"settings.autoUpdates" = "Mises à jour automatiques";
+"settings.autoUpdates.help" = "Rechercher les nouvelles versions en arrière-plan et proposer de les installer";
 "settings.showInDock" = "Montrer dans le Dock";
 "settings.showInDock.help" = "Garde Dorso visible dans le Dock et avec Cmd+Tab";
 "settings.blurWhenAway" = "Flouter en cas d'absence";

--- a/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Resources/ja.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "menu.analytics" = "統計";
 "menu.settings" = "設定";
 "menu.quit" = "終了";
+"menu.checkForUpdates" = "アップデートを確認…";
 
 // MARK: - App Menu (DorsoMain.swift)
 
@@ -148,6 +149,8 @@
 "settings.detection.help" = "応答速度とバッテリーのバランス。高速は素早く検出し、省エネはバッテリーを節約します。";
 "settings.launchAtLogin" = "ログイン時に起動";
 "settings.launchAtLogin.help" = "ログイン時に Dorso を自動的に起動";
+"settings.autoUpdates" = "自動アップデート";
+"settings.autoUpdates.help" = "バックグラウンドで新しいバージョンを確認し、インストールを提案";
 "settings.showInDock" = "Dock に表示";
 "settings.showInDock.help" = "Dorso を Dock と Cmd+Tab に表示";
 "settings.blurWhenAway" = "離席時にぼかす";

--- a/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "menu.analytics" = "统计";
 "menu.settings" = "设置";
 "menu.quit" = "退出";
+"menu.checkForUpdates" = "检查更新…";
 
 // MARK: - App Menu (DorsoMain.swift)
 
@@ -148,6 +149,8 @@
 "settings.detection.help" = "在响应速度和电池之间取得平衡。快速响应检测迅速，省电模式节省电量。";
 "settings.launchAtLogin" = "登录时启动";
 "settings.launchAtLogin.help" = "登录时自动启动 Dorso";
+"settings.autoUpdates" = "自动更新";
+"settings.autoUpdates.help" = "在后台检查新版本并提示安装";
 "settings.showInDock" = "在程序坞中显示";
 "settings.showInDock.help" = "在程序坞和 Cmd+Tab 中显示 Dorso";
 "settings.blurWhenAway" = "离开时模糊";

--- a/Sources/System/UpdaterManager.swift
+++ b/Sources/System/UpdaterManager.swift
@@ -1,0 +1,34 @@
+#if !APP_STORE
+import AppKit
+import Sparkle
+
+// MARK: - Updater Manager
+
+/// Owns the Sparkle auto-updater for direct-distribution (GitHub) builds.
+/// App Store builds compile this out entirely; the App Store delivers
+/// updates for those installs.
+@MainActor
+final class UpdaterManager {
+    private let controller: SPUStandardUpdaterController
+
+    init() {
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    }
+
+    func checkForUpdates() {
+        controller.checkForUpdates(nil)
+    }
+
+    /// Whether Sparkle checks for updates in the background. Persisted by
+    /// Sparkle itself; setting it explicitly also suppresses Sparkle's
+    /// first-run permission prompt.
+    var automaticallyChecksForUpdates: Bool {
+        get { controller.updater.automaticallyChecksForUpdates }
+        set { controller.updater.automaticallyChecksForUpdates = newValue }
+    }
+}
+#endif

--- a/Sources/UI/MenuBar.swift
+++ b/Sources/UI/MenuBar.swift
@@ -16,6 +16,9 @@ final class MenuBarManager {
     var onOpenSettings: (() -> Void)?
     var onOpenSupport: (() -> Void)?
     var onQuit: (() -> Void)?
+    #if !APP_STORE
+    var onCheckForUpdates: (() -> Void)?
+    #endif
 
     func setup() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -71,6 +74,15 @@ final class MenuBarManager {
         settingsItem.target = self
         settingsItem.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: L("menu.settings"))
         menu.addItem(settingsItem)
+
+        #if !APP_STORE
+        // Check for Updates (direct-distribution builds only; the App Store
+        // delivers updates for Mac App Store installs)
+        let updatesItem = NSMenuItem(title: L("menu.checkForUpdates"), action: #selector(handleCheckForUpdates), keyEquivalent: "")
+        updatesItem.target = self
+        updatesItem.image = NSImage(systemSymbolName: "arrow.triangle.2.circlepath", accessibilityDescription: L("menu.checkForUpdates"))
+        menu.addItem(updatesItem)
+        #endif
 
         menu.addItem(NSMenuItem.separator())
 
@@ -138,4 +150,10 @@ final class MenuBarManager {
     @objc private func handleQuit() {
         onQuit?()
     }
+
+    #if !APP_STORE
+    @objc private func handleCheckForUpdates() {
+        onCheckForUpdates?()
+    }
+    #endif
 }

--- a/Sources/UI/SettingsWindow.swift
+++ b/Sources/UI/SettingsWindow.swift
@@ -26,6 +26,9 @@ struct SettingsView: View {
     @State private var warningColor: Color
     @State private var warningOnsetDelay: Double
     @State private var launchAtLogin: Bool
+    #if !APP_STORE
+    @State private var autoCheckForUpdates: Bool
+    #endif
     @State private var toggleShortcutEnabled: Bool
     @State private var toggleShortcut: KeyboardShortcut
     @State private var detectionModeSlider: Double
@@ -92,6 +95,9 @@ struct SettingsView: View {
         _warningColor = State(initialValue: Color(profileWarningColor))
         _warningOnsetDelay = State(initialValue: profileWarningOnsetDelay)
         _launchAtLogin = State(initialValue: SMAppService.mainApp.status == .enabled)
+        #if !APP_STORE
+        _autoCheckForUpdates = State(initialValue: appDelegate.updaterManager?.automaticallyChecksForUpdates ?? false)
+        #endif
         _toggleShortcutEnabled = State(initialValue: appDelegate.toggleShortcutEnabled)
         _toggleShortcut = State(initialValue: appDelegate.toggleShortcut)
         _detectionModeSlider = State(initialValue: Double(detectionModes.firstIndex(of: profileDetectionMode) ?? 0))
@@ -613,6 +619,23 @@ struct SettingsView: View {
                         .frame(maxWidth: .infinity)
                     #endif
                 }
+
+                #if !APP_STORE
+                HStack(spacing: 0) {
+                    CompactToggle(
+                        title: L("settings.autoUpdates"),
+                        helpText: L("settings.autoUpdates.help"),
+                        isOn: $autoCheckForUpdates
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .onChange(of: autoCheckForUpdates) { newValue in
+                        appDelegate.updaterManager?.automaticallyChecksForUpdates = newValue
+                    }
+
+                    Spacer()
+                        .frame(maxWidth: .infinity)
+                }
+                #endif
             }
             .padding(.vertical, 10)
         }

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+    <channel>
+        <title>Dorso</title>
+        <link>https://github.com/tldev/dorso</link>
+        <description>Most recent updates to Dorso</description>
+        <language>en</language>
+        <!-- release.sh inserts new release items below this line -->
+    </channel>
+</rss>

--- a/build.sh
+++ b/build.sh
@@ -18,15 +18,24 @@ VERSION="1.13.0"
 BUILD_NUMBER="12"
 MIN_MACOS="13.0"
 
+# Sparkle auto-update (direct-distribution builds only; App Store builds
+# exclude Sparkle entirely and rely on the App Store for updates)
+SPARKLE_FEED_URL="https://raw.githubusercontent.com/tldev/dorso/main/appcast.xml"
+SPARKLE_PUBLIC_ED_KEY="DGZFLiX7GOAurNDYQQQaoR4Hb4csYScDIIiui74ZvLY="
+
 # Check for App Store build flag
 APP_STORE_BUILD=false
 DEV_BUILD=false
 BUILD_CONFIG="release"
-SWIFT_BUILD_FLAGS=()
 if [[ "$*" == *"--appstore"* ]]; then
     APP_STORE_BUILD=true
-    SWIFT_BUILD_FLAGS=(-Xswiftc -D -Xswiftc APP_STORE)
+    # -dead_strip_dylibs removes the Sparkle load command (all Sparkle code is
+    # compiled out via APP_STORE, so nothing references it)
+    SWIFT_BUILD_FLAGS=(-Xswiftc -D -Xswiftc APP_STORE -Xlinker -dead_strip_dylibs)
     echo "Building for App Store (no private APIs)..."
+else
+    # Resolve the embedded Sparkle.framework from Contents/Frameworks
+    SWIFT_BUILD_FLAGS=(-Xlinker -rpath -Xlinker @executable_path/../Frameworks)
 fi
 if [[ "$*" == *"--dev"* ]]; then
     DEV_BUILD=true
@@ -115,6 +124,21 @@ else
     rm "$MACOS_DIR/${APP_NAME}_arm64" "$MACOS_DIR/${APP_NAME}_x86"
 fi
 
+# Embed Sparkle.framework (direct-distribution builds only)
+if [ "$APP_STORE_BUILD" = false ]; then
+    SPARKLE_FRAMEWORK="$SCRIPT_DIR/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
+    if [ ! -d "$SPARKLE_FRAMEWORK" ]; then
+        echo -e "${RED}Error: Sparkle.framework not found at $SPARKLE_FRAMEWORK${NC}"
+        echo "Run 'swift package resolve' to fetch it."
+        exit 1
+    fi
+    echo "Embedding Sparkle.framework..."
+    mkdir -p "$CONTENTS/Frameworks"
+    # ditto preserves the framework's internal symlinks (required for a valid
+    # code signature)
+    ditto "$SPARKLE_FRAMEWORK" "$CONTENTS/Frameworks/Sparkle.framework"
+fi
+
 # Create Info.plist
 echo "Creating Info.plist..."
 cat > "$CONTENTS/Info.plist" << EOF
@@ -170,6 +194,15 @@ cat > "$CONTENTS/Info.plist" << EOF
 </dict>
 </plist>
 EOF
+
+# Sparkle update feed keys (direct-distribution builds only; App Store builds
+# must not reference an update feed)
+if [ "$APP_STORE_BUILD" = false ]; then
+    /usr/libexec/PlistBuddy \
+        -c "Add :SUFeedURL string $SPARKLE_FEED_URL" \
+        -c "Add :SUPublicEDKey string $SPARKLE_PUBLIC_ED_KEY" \
+        "$CONTENTS/Info.plist"
+fi
 
 # Compile app icon
 # Priority: .icon file (Icon Composer) > .icns file > .iconset folder
@@ -289,8 +322,9 @@ if [ -f "$MACOS_DIR/$APP_NAME" ]; then
     if [ "$1" == "--release" ]; then
         echo "Creating release archive..."
         RELEASE_NAME="$APP_NAME-v$VERSION.zip"
-        cd "$BUILD_DIR"
-        zip -r -q "$RELEASE_NAME" "$APP_NAME.app"
+        # ditto preserves Sparkle.framework's symlinks; zip -r would flatten
+        # them and break the code signature
+        ditto -c -k --keepParent "$APP_BUNDLE" "$BUILD_DIR/$RELEASE_NAME"
         echo -e "${GREEN}Release archive created: $BUILD_DIR/$RELEASE_NAME${NC}"
     fi
 else

--- a/build.sh
+++ b/build.sh
@@ -136,6 +136,8 @@ cat > "$CONTENTS/Info.plist" << EOF
     <string>$VERSION</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
     <key>LSMinimumSystemVersion</key>
     <string>$MIN_MACOS</string>
     <key>LSUIElement</key>

--- a/build.sh
+++ b/build.sh
@@ -14,8 +14,8 @@ set -e
 # Configuration
 APP_NAME="Dorso"
 BUNDLE_ID="com.thelazydeveloper.posturr"
-VERSION="1.13.0"
-BUILD_NUMBER="12"
+VERSION="1.14.0"
+BUILD_NUMBER="13"
 MIN_MACOS="13.0"
 
 # Sparkle auto-update (direct-distribution builds only; App Store builds

--- a/release.sh
+++ b/release.sh
@@ -109,6 +109,28 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
     exit 1
 fi
 
+# The appcast entry is generated from build.sh's version fields, so they must
+# match the release version or auto-update would offer the wrong build
+BUILD_SH_VERSION=$(grep '^VERSION=' build.sh | cut -d'"' -f2)
+BUILD_NUMBER=$(grep '^BUILD_NUMBER=' build.sh | cut -d'"' -f2)
+MIN_MACOS=$(grep '^MIN_MACOS=' build.sh | cut -d'"' -f2)
+if [ "$VERSION" != "$BUILD_SH_VERSION" ]; then
+    echo -e "${RED}Error: release version $VERSION does not match build.sh VERSION=$BUILD_SH_VERSION${NC}"
+    echo "Bump VERSION (and BUILD_NUMBER) in build.sh first."
+    exit 1
+fi
+
+# Sparkle tools ship with the SwiftPM artifact
+SPARKLE_BIN="$SCRIPT_DIR/.build/artifacts/sparkle/Sparkle/bin"
+if [ ! -x "$SPARKLE_BIN/sign_update" ]; then
+    echo -e "${YELLOW}Sparkle tools not found; fetching packages...${NC}"
+    swift package resolve
+fi
+if [ ! -x "$SPARKLE_BIN/sign_update" ]; then
+    echo -e "${RED}Error: sign_update not found at $SPARKLE_BIN${NC}"
+    exit 1
+fi
+
 TAG="v$VERSION"
 ZIP_NAME="Dorso-$TAG.zip"
 DMG_NAME="Dorso-$TAG.dmg"
@@ -143,11 +165,21 @@ if git rev-parse "$TAG" >/dev/null 2>&1; then
 fi
 
 # Step 1: Build
-echo -e "${GREEN}[1/7] Building app...${NC}"
+echo -e "${GREEN}[1/8] Building app...${NC}"
 ./build.sh
 
 # Step 2: Code sign with Developer ID
-echo -e "${GREEN}[2/7] Signing app with Developer ID...${NC}"
+echo -e "${GREEN}[2/8] Signing app with Developer ID...${NC}"
+
+# Sign Sparkle's nested components first (inside-out order), per Sparkle's
+# distribution docs. All need hardened runtime for notarization.
+SPARKLE_FW="build/Dorso.app/Contents/Frameworks/Sparkle.framework"
+codesign --force --options runtime --sign "$DEVELOPER_ID" --timestamp "$SPARKLE_FW/Versions/B/XPCServices/Installer.xpc"
+codesign --force --options runtime --preserve-metadata=entitlements --sign "$DEVELOPER_ID" --timestamp "$SPARKLE_FW/Versions/B/XPCServices/Downloader.xpc"
+codesign --force --options runtime --sign "$DEVELOPER_ID" --timestamp "$SPARKLE_FW/Versions/B/Autoupdate"
+codesign --force --options runtime --sign "$DEVELOPER_ID" --timestamp "$SPARKLE_FW/Versions/B/Updater.app"
+codesign --force --options runtime --sign "$DEVELOPER_ID" --timestamp "$SPARKLE_FW"
+
 codesign --force --options runtime --entitlements "build/Dorso.entitlements" --sign "$DEVELOPER_ID" --timestamp "build/Dorso.app"
 
 # Verify signature
@@ -156,24 +188,26 @@ codesign --verify --deep --strict "build/Dorso.app"
 echo -e "${GREEN}Signature verified${NC}"
 
 # Step 3: Create ZIP for notarization
-echo -e "${GREEN}[3/7] Creating ZIP for notarization...${NC}"
+# ditto preserves Sparkle.framework's symlinks; zip -r would flatten them and
+# break the code signature
+echo -e "${GREEN}[3/8] Creating ZIP for notarization...${NC}"
 rm -f "build/$ZIP_NAME"
-cd build && zip -r "$ZIP_NAME" Dorso.app && cd ..
+ditto -c -k --keepParent build/Dorso.app "build/$ZIP_NAME"
 
 # Step 4: Submit for notarization
-echo -e "${GREEN}[4/7] Submitting for notarization (this may take a few minutes)...${NC}"
+echo -e "${GREEN}[4/8] Submitting for notarization (this may take a few minutes)...${NC}"
 xcrun notarytool submit "build/$ZIP_NAME" --keychain-profile "$NOTARY_PROFILE" --wait
 
 # Step 5: Staple the notarization ticket
-echo -e "${GREEN}[5/7] Stapling notarization ticket...${NC}"
+echo -e "${GREEN}[5/8] Stapling notarization ticket...${NC}"
 xcrun stapler staple "build/Dorso.app"
 
 # Recreate ZIP with stapled app
 rm -f "build/$ZIP_NAME"
-cd build && zip -r "$ZIP_NAME" Dorso.app && cd ..
+ditto -c -k --keepParent build/Dorso.app "build/$ZIP_NAME"
 
 # Step 6: Create DMG (with notarized app)
-echo -e "${GREEN}[6/7] Creating DMG...${NC}"
+echo -e "${GREEN}[6/8] Creating DMG...${NC}"
 hdiutil detach /Volumes/Dorso 2>/dev/null || true
 rm -f "build/$DMG_NAME"
 
@@ -202,7 +236,7 @@ echo "Stapling DMG..."
 xcrun stapler staple "build/$DMG_NAME"
 
 # Step 7: Create git tag and GitHub release
-echo -e "${GREEN}[7/7] Creating git tag and GitHub release...${NC}"
+echo -e "${GREEN}[7/8] Creating git tag and GitHub release...${NC}"
 git tag "$TAG"
 git push origin "$TAG"
 
@@ -247,6 +281,56 @@ else
         --notes "$RELEASE_NOTES"
 
     echo -e "${GREEN}Release created!${NC}"
+fi
+
+# Step 8: Update the Sparkle appcast so existing installs see this release.
+# The EdDSA signature must be of the exact ZIP uploaded to GitHub.
+echo -e "${GREEN}[8/8] Updating appcast...${NC}"
+SIGN_ATTRS=$("$SPARKLE_BIN/sign_update" "build/$ZIP_NAME")
+PUB_DATE=$(LC_ALL=C date "+%a, %d %b %Y %H:%M:%S %z")
+DOWNLOAD_URL="https://github.com/tldev/dorso/releases/download/$TAG/$ZIP_NAME"
+RELEASE_URL="https://github.com/tldev/dorso/releases/tag/$TAG"
+
+# Drop any existing appcast item for this tag (re-release), then insert the
+# new item below the marker comment
+awk -v tag="releases/download/$TAG/" '
+    /<item>/ { buf = $0 ORS; initem = 1; drop = 0; next }
+    initem {
+        buf = buf $0 ORS
+        if (index($0, tag)) drop = 1
+        if (/<\/item>/) { if (!drop) printf "%s", buf; initem = 0 }
+        next
+    }
+    { print }
+' appcast.xml > build/appcast.tmp && mv build/appcast.tmp appcast.xml
+
+cat > build/appcast-item.xml << EOF
+        <item>
+            <title>Version $VERSION</title>
+            <link>$RELEASE_URL</link>
+            <sparkle:version>$BUILD_NUMBER</sparkle:version>
+            <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>$MIN_MACOS</sparkle:minimumSystemVersion>
+            <sparkle:releaseNotesLink>$RELEASE_URL</sparkle:releaseNotesLink>
+            <pubDate>$PUB_DATE</pubDate>
+            <enclosure
+                url="$DOWNLOAD_URL"
+                $SIGN_ATTRS
+                type="application/octet-stream"/>
+        </item>
+EOF
+sed -i '' "/release.sh inserts new release items below this line/r build/appcast-item.xml" appcast.xml
+rm -f build/appcast-item.xml
+
+if ! git diff --quiet -- appcast.xml; then
+    git commit -m "Update appcast for $TAG" -- appcast.xml
+    if git push origin HEAD; then
+        echo -e "${GREEN}Appcast published${NC}"
+    else
+        echo -e "${YELLOW}Could not push appcast.xml; push it manually or the update will not reach users${NC}"
+    fi
+else
+    echo -e "${YELLOW}appcast.xml unchanged; nothing to publish${NC}"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

GitHub (direct-distribution) builds now update themselves via Sparkle 2.9.4. App Store builds are untouched: Sparkle is compiled out via the `APP_STORE` flag and `-dead_strip_dylibs` removes the linkage, so the MAS binary contains no trace of it and keeps updating through the App Store.

### What's included
- "Check for Updates…" menu bar item and an "Automatic updates" toggle in Settings, localized in all six languages
- `build.sh` embeds Sparkle.framework, adds the update feed keys to Info.plist for GitHub builds only
- `release.sh` signs Sparkle's nested components, EdDSA-signs the release ZIP, and maintains `appcast.xml` (served from raw.githubusercontent.com, so no extra hosting)
- Release ZIPs switched from `zip -r` to `ditto` so the framework's symlinks survive archiving (required for a valid code signature)
- Also lands the previously local ITSAppUsesNonExemptEncryption commit

### Testing
- Full test suite passes headless (404 tests)
- App Store flavor verified to contain zero Sparkle traces (otool, strings, no Frameworks dir)
- Full update flow verified end to end locally: a signed 1.12.0 install detected, downloaded, EdDSA-validated, and silently installed a newer build from a served appcast, with the code signature intact afterward

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)