### PR TITLE
Fix stale blur when toggling compatibility mode while blurred

### DIFF
--- a/Sources/UI/SettingsWindow.swift
+++ b/Sources/UI/SettingsWindow.swift
@@ -609,10 +609,11 @@ struct SettingsView: View {
                     .onChange(of: useCompatibilityMode) { newValue in
                         appDelegate.useCompatibilityMode = newValue
                         appDelegate.saveSettings()
-                        appDelegate.currentBlurRadius = 0
-                        for blurView in appDelegate.blurViews {
-                            blurView.alphaValue = 0
-                        }
+                        // Clear both blur mechanisms, not just the visual
+                        // effect views: the CGS background blur radius of the
+                        // outgoing private-API path survives alpha resets and
+                        // would otherwise stay on screen indefinitely
+                        appDelegate.clearBlur()
                     }
                     #else
                     Spacer()

--- a/build.sh
+++ b/build.sh
@@ -14,8 +14,8 @@ set -e
 # Configuration
 APP_NAME="Dorso"
 BUNDLE_ID="com.thelazydeveloper.posturr"
-VERSION="1.14.0"
-BUILD_NUMBER="13"
+VERSION="1.14.1"
+BUILD_NUMBER="14"
 MIN_MACOS="13.0"
 
 # Sparkle auto-update (direct-distribution builds only; App Store builds


### PR DESCRIPTION
## Summary

Toggling compatibility mode while the screen is blurred left the screen stuck blurred: the handler reset the visual effect views and the tracked ramp but never cleared the CGS background blur the private API path had already applied to the overlay windows. The toggle now routes through `clearBlur()`, which resets both mechanisms; the next update tick rebuilds the ramp from live posture state, so an active slouch fades back in through the newly selected mechanism.

## Testing
- Full test suite passes headless
- Verified manually: blur active, toggled compatibility mode both directions; blur clears and re-ramps instead of sticking

🤖 Generated with [Claude Code](https://claude.com/claude-code)