### PR TITLE
Surface scheduled update alerts for the menu bar app

### DIFF
--- a/Sources/System/UpdaterManager.swift
+++ b/Sources/System/UpdaterManager.swift
@@ -8,14 +8,15 @@ import Sparkle
 /// App Store builds compile this out entirely; the App Store delivers
 /// updates for those installs.
 @MainActor
-final class UpdaterManager {
-    private let controller: SPUStandardUpdaterController
+final class UpdaterManager: NSObject {
+    private var controller: SPUStandardUpdaterController!
 
-    init() {
+    override init() {
+        super.init()
         controller = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: nil,
-            userDriverDelegate: nil
+            userDriverDelegate: self
         )
     }
 
@@ -29,6 +30,26 @@ final class UpdaterManager {
     var automaticallyChecksForUpdates: Bool {
         get { controller.updater.automaticallyChecksForUpdates }
         set { controller.updater.automaticallyChecksForUpdates = newValue }
+    }
+}
+
+// MARK: - Gentle Reminders
+
+extension UpdaterManager: SPUStandardUserDriverDelegate {
+    nonisolated var supportsGentleScheduledUpdateReminders: Bool { true }
+
+    nonisolated func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool,
+        forUpdate update: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        // Sparkle shows scheduled update alerts without activating the app;
+        // for a menu bar app that leaves the alert buried behind other
+        // windows. Bring the app forward so the alert is actually seen.
+        guard !state.userInitiated else { return }
+        MainActor.assumeIsolated {
+            NSApp.activate(ignoringOtherApps: true)
+        }
     }
 }
 #endif

--- a/build.sh
+++ b/build.sh
@@ -14,8 +14,8 @@ set -e
 # Configuration
 APP_NAME="Dorso"
 BUNDLE_ID="com.thelazydeveloper.posturr"
-VERSION="1.14.1"
-BUILD_NUMBER="14"
+VERSION="1.14.2"
+BUILD_NUMBER="15"
 MIN_MACOS="13.0"
 
 # Sparkle auto-update (direct-distribution builds only; App Store builds


### PR DESCRIPTION
## Summary

Sparkle does not bring update alerts forward for background (LSUIElement) apps on scheduled checks; it logs a "gentle reminders" warning and the alert is never visible for a menu bar app. Users with background checking enabled but silent installs off would never see scheduled updates.

This adopts `SPUStandardUserDriverDelegate`: declares gentle-reminder support and activates the app when a scheduled update alert is about to show, so the dialog appears front and center. Manual checks are unaffected (already focused), silent installs are unaffected (no UI by design), and the alert appears at most once per scheduled check while an update is pending, with the standard Remind Me Later / Skip This Version options.

## Testing
- Full test suite passes headless
- Verified via unified log that Sparkle detects the delegate (its background-app gentle-reminders warning is no longer emitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)