### PR TITLE
Redesign Settings window and add appearance setting

### DIFF
--- a/Sources/AppDelegate/AppDelegate+Persistence.swift
+++ b/Sources/AppDelegate/AppDelegate+Persistence.swift
@@ -15,6 +15,7 @@ extension AppDelegate {
     func saveSettings() {
         let defaults = UserDefaults.standard
         defaults.set(useCompatibilityMode, forKey: SettingsKeys.useCompatibilityMode)
+        defaults.set(appAppearance.rawValue, forKey: SettingsKeys.appAppearance)
         defaults.set(blurWhenAway, forKey: SettingsKeys.blurWhenAway)
         defaults.set(showInDock, forKey: SettingsKeys.showInDock)
         defaults.set(pauseOnTheGo, forKey: SettingsKeys.pauseOnTheGo)
@@ -43,6 +44,10 @@ extension AppDelegate {
         applyActiveSettingsProfile()
 
         useCompatibilityMode = defaults.bool(forKey: SettingsKeys.useCompatibilityMode)
+        if let appearanceString = defaults.string(forKey: SettingsKeys.appAppearance),
+           let appearance = AppAppearance(rawValue: appearanceString) {
+            appAppearance = appearance
+        }
         blurWhenAway = defaults.bool(forKey: SettingsKeys.blurWhenAway)
         showInDock = defaults.bool(forKey: SettingsKeys.showInDock)
         pauseOnTheGo = defaults.bool(forKey: SettingsKeys.pauseOnTheGo)

--- a/Sources/AppDelegate/AppDelegate.swift
+++ b/Sources/AppDelegate/AppDelegate.swift
@@ -118,6 +118,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     var showInDock = false
+    var appAppearance = AppAppearance.auto
     var pauseOnTheGo = false
     var pauseOnBattery: Bool {
         trackingStore.withState { $0.pauseOnBatteryEnabled }
@@ -368,13 +369,24 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
+    // MARK: - Appearance
+
+    func applyAppearance() {
+        NSApp.appearance = appAppearance.nsAppearance
+    }
+
     // MARK: - App Lifecycle
 
     public func applicationDidFinishLaunching(_ notification: Notification) {
         // Ensure analytics storage migration runs as soon as the app launches.
         _ = AnalyticsManager.shared
 
+        // Snappier tooltips: AppKit's ~1.8s default delay makes the compact
+        // status glyphs in Settings feel unexplained
+        UserDefaults.standard.register(defaults: ["NSInitialToolTipDelay": 250])
+
         loadSettings()
+        applyAppearance()
 
         if showInDock {
             NSApp.setActivationPolicy(.regular)
@@ -386,7 +398,12 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         #if !APP_STORE
-        updaterManager = UpdaterManager()
+        // UI preview launches must not start the updater: with silent
+        // updates enabled it can stage and install a store build over the
+        // dev build mid-iteration
+        if !CommandLine.arguments.contains("--open-settings") {
+            updaterManager = UpdaterManager()
+        }
         #endif
 
         setupDetectors()
@@ -411,6 +428,18 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
 
         if isMarketingMode {
             AnalyticsManager.shared.injectMarketingData()
+        }
+
+        // Dev affordance for UI iteration: open Settings immediately and skip
+        // the tracking setup flow so no camera/permission prompts fire.
+        if CommandLine.arguments.contains("--open-settings") {
+            if CommandLine.arguments.contains("--appearance-dark") {
+                NSApp.appearance = NSAppearance(named: .darkAqua)
+            } else if CommandLine.arguments.contains("--appearance-light") {
+                NSApp.appearance = NSAppearance(named: .aqua)
+            }
+            openSettings()
+            return
         }
 
         Task { @MainActor in

--- a/Sources/Core/Models.swift
+++ b/Sources/Core/Models.swift
@@ -178,3 +178,28 @@ enum DetectionMode: String, CaseIterable, Codable {
         }
     }
 }
+
+// MARK: - App Appearance
+
+/// User-selected window appearance: follow the system or force light/dark.
+public enum AppAppearance: String, CaseIterable, Sendable {
+    case auto
+    case light
+    case dark
+
+    var displayName: String {
+        switch self {
+        case .auto: return L("settings.appearance.auto")
+        case .light: return L("settings.appearance.light")
+        case .dark: return L("settings.appearance.dark")
+        }
+    }
+
+    var nsAppearance: NSAppearance? {
+        switch self {
+        case .auto: return nil
+        case .light: return NSAppearance(named: .aqua)
+        case .dark: return NSAppearance(named: .darkAqua)
+        }
+    }
+}

--- a/Sources/Resources/de.lproj/Localizable.strings
+++ b/Sources/Resources/de.lproj/Localizable.strings
@@ -122,6 +122,13 @@
 "settings.mode.manual" = "Manuell";
 "settings.mode.automatic" = "Automatisch";
 "settings.preferred" = "Bevorzugt";
+"settings.source" = "Quelle";
+"settings.section.response" = "Haltungsreaktion";
+"settings.section.behavior" = "Verhalten";
+"settings.appearance" = "Erscheinungsbild";
+"settings.appearance.auto" = "Auto";
+"settings.appearance.light" = "Hell";
+"settings.appearance.dark" = "Dunkel";
 "settings.active" = "Aktiv";
 "settings.calibrated" = "Kalibriert";
 "settings.notCalibrated" = "Nicht kalibriert";

--- a/Sources/Resources/en.lproj/Localizable.strings
+++ b/Sources/Resources/en.lproj/Localizable.strings
@@ -122,6 +122,13 @@
 "settings.mode.manual" = "Manual";
 "settings.mode.automatic" = "Automatic";
 "settings.preferred" = "Preferred";
+"settings.source" = "Source";
+"settings.section.response" = "Posture response";
+"settings.section.behavior" = "Behavior";
+"settings.appearance" = "Appearance";
+"settings.appearance.auto" = "Auto";
+"settings.appearance.light" = "Light";
+"settings.appearance.dark" = "Dark";
 "settings.active" = "Active";
 "settings.calibrated" = "Calibrated";
 "settings.notCalibrated" = "Not calibrated";

--- a/Sources/Resources/es.lproj/Localizable.strings
+++ b/Sources/Resources/es.lproj/Localizable.strings
@@ -122,6 +122,13 @@
 "settings.mode.manual" = "Manual";
 "settings.mode.automatic" = "Automático";
 "settings.preferred" = "Preferido";
+"settings.source" = "Fuente";
+"settings.section.response" = "Respuesta postural";
+"settings.section.behavior" = "Comportamiento";
+"settings.appearance" = "Apariencia";
+"settings.appearance.auto" = "Auto";
+"settings.appearance.light" = "Claro";
+"settings.appearance.dark" = "Oscuro";
 "settings.active" = "Activo";
 "settings.calibrated" = "Calibrado";
 "settings.notCalibrated" = "Sin calibrar";

--- a/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Resources/fr.lproj/Localizable.strings
@@ -122,6 +122,13 @@
 "settings.mode.manual" = "Manuel";
 "settings.mode.automatic" = "Automatique";
 "settings.preferred" = "Préférée";
+"settings.source" = "Source";
+"settings.section.response" = "Réponse posturale";
+"settings.section.behavior" = "Comportement";
+"settings.appearance" = "Apparence";
+"settings.appearance.auto" = "Auto";
+"settings.appearance.light" = "Clair";
+"settings.appearance.dark" = "Sombre";
 "settings.active" = "Active";
 "settings.calibrated" = "Calibrée";
 "settings.notCalibrated" = "Non calibrée";

--- a/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Resources/ja.lproj/Localizable.strings
@@ -122,6 +122,13 @@
 "settings.mode.manual" = "手動";
 "settings.mode.automatic" = "自動";
 "settings.preferred" = "優先";
+"settings.source" = "ソース";
+"settings.section.response" = "姿勢への反応";
+"settings.section.behavior" = "動作";
+"settings.appearance" = "外観";
+"settings.appearance.auto" = "自動";
+"settings.appearance.light" = "ライト";
+"settings.appearance.dark" = "ダーク";
 "settings.active" = "使用中";
 "settings.calibrated" = "校正済み";
 "settings.notCalibrated" = "未校正";

--- a/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -122,6 +122,13 @@
 "settings.mode.manual" = "手动";
 "settings.mode.automatic" = "自动";
 "settings.preferred" = "首选";
+"settings.source" = "来源";
+"settings.section.response" = "姿势响应";
+"settings.section.behavior" = "行为";
+"settings.appearance" = "外观";
+"settings.appearance.auto" = "自动";
+"settings.appearance.light" = "浅色";
+"settings.appearance.dark" = "深色";
 "settings.active" = "活跃";
 "settings.calibrated" = "已校准";
 "settings.notCalibrated" = "未校准";

--- a/Sources/Settings/SettingsKeys.swift
+++ b/Sources/Settings/SettingsKeys.swift
@@ -6,6 +6,7 @@ enum SettingsKeys {
     static let intensity = "intensity"
     static let deadZone = "deadZone"
     static let useCompatibilityMode = "useCompatibilityMode"
+    static let appAppearance = "appAppearance"
     static let blurWhenAway = "blurWhenAway"
     static let showInDock = "showInDock"
     static let pauseOnTheGo = "pauseOnTheGo"

--- a/Sources/UI/SettingsComponents.swift
+++ b/Sources/UI/SettingsComponents.swift
@@ -16,6 +16,70 @@ extension Color {
     })
 }
 
+// MARK: - Settings Card
+
+/// Section container per the brand guidelines: control-background fill,
+/// subtle border, icon + semibold header with an optional trailing control.
+struct SettingsCard<Trailing: View, Content: View>: View {
+    let icon: String
+    let title: String
+    let helpText: String?
+    @ViewBuilder let trailing: () -> Trailing
+    @ViewBuilder let content: () -> Content
+
+    init(
+        icon: String,
+        title: String,
+        helpText: String? = nil,
+        @ViewBuilder trailing: @escaping () -> Trailing,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.icon = icon
+        self.title = title
+        self.helpText = helpText
+        self.trailing = trailing
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.brandCyan)
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                if let helpText {
+                    HelpButton(text: helpText)
+                }
+                Spacer(minLength: 8)
+                trailing()
+            }
+            content()
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color(NSColor.controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
+        )
+    }
+}
+
+extension SettingsCard where Trailing == EmptyView {
+    init(
+        icon: String,
+        title: String,
+        helpText: String? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.init(icon: icon, title: title, helpText: helpText, trailing: { EmptyView() }, content: content)
+    }
+}
+
 // MARK: - Compact Slider
 
 struct CompactSlider: View {
@@ -35,14 +99,88 @@ struct CompactSlider: View {
                 HelpButton(text: helpText)
             }
 
-            Slider(value: $value, in: range, step: step)
-                .tint(.brandCyan)
+            SteppedSliderTrack(value: $value, range: range, step: step)
                 .frame(maxWidth: .infinity)
 
             Text(valueLabel)
                 .font(.system(size: 10, weight: .medium))
                 .foregroundColor(.brandCyan)
-                .frame(width: 70, alignment: .trailing)
+                .lineLimit(1)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
+                .background(Capsule().fill(Color.brandCyan.opacity(0.12)))
+                .frame(width: 86, alignment: .trailing)
+        }
+        .frame(height: 22)
+    }
+}
+
+// MARK: - Stepped Slider Track
+
+/// Minimal slider replacement for stepped values: quiet capsule track,
+/// brand-cyan fill, and small step dots only when the step count is low
+/// enough to read (the system slider draws a tick per step, which turns a
+/// 30-step range into visual noise).
+struct SteppedSliderTrack: View {
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    let step: Double
+
+    private let thumbRadius: CGFloat = 7
+
+    private var fraction: CGFloat {
+        let span = range.upperBound - range.lowerBound
+        guard span > 0 else { return 0 }
+        return CGFloat((value - range.lowerBound) / span)
+    }
+
+    private var stepCount: Int {
+        max(1, Int(((range.upperBound - range.lowerBound) / step).rounded()))
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let width = geo.size.width
+            let usable = width - thumbRadius * 2
+            let thumbX = thumbRadius + usable * fraction
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.primary.opacity(0.08))
+                    .frame(height: 4)
+                Capsule()
+                    .fill(Color.brandCyan.opacity(0.85))
+                    .frame(width: max(0, thumbX), height: 4)
+
+                if stepCount <= 8 {
+                    ForEach(1..<stepCount, id: \.self) { i in
+                        Circle()
+                            .fill(Color.primary.opacity(0.15))
+                            .frame(width: 3, height: 3)
+                            .position(
+                                x: thumbRadius + usable * CGFloat(i) / CGFloat(stepCount),
+                                y: geo.size.height / 2
+                            )
+                    }
+                }
+
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: thumbRadius * 2, height: thumbRadius * 2)
+                    .overlay(Circle().strokeBorder(Color.black.opacity(0.12), lineWidth: 0.5))
+                    .shadow(color: .black.opacity(0.18), radius: 1.5, y: 0.5)
+                    .position(x: thumbX, y: geo.size.height / 2)
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { gesture in
+                        let f = min(1, max(0, (gesture.location.x - thumbRadius) / usable))
+                        let raw = range.lowerBound + Double(f) * (range.upperBound - range.lowerBound)
+                        let stepped = (raw / step).rounded() * step
+                        value = min(range.upperBound, max(range.lowerBound, stepped))
+                    }
+            )
         }
         .frame(height: 22)
     }
@@ -348,6 +486,39 @@ struct BrightnessSliderView: View {
     }
 }
 
+// MARK: - Compact Segmented Picker
+
+/// Generic brand-styled segmented control for small option sets.
+struct CompactSegmentedPicker<Value: Hashable>: View {
+    @Binding var selection: Value
+    let options: [(value: Value, label: String)]
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(options, id: \.value) { option in
+                Button(action: { selection = option.value }) {
+                    Text(option.label)
+                        .font(.system(size: 10, weight: selection == option.value ? .semibold : .regular))
+                        .foregroundColor(selection == option.value ? .onBrandCyan : .primary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 5)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                .fill(selection == option.value ? Color.brandCyan : Color.clear)
+                        )
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.06))
+        )
+    }
+}
+
 // MARK: - Compact Mode Picker
 
 struct CompactModePicker: View {
@@ -402,15 +573,24 @@ struct DeviceStatusRow: View {
                 .font(.system(size: 11, weight: isPreferred ? .medium : .regular))
                 .frame(width: 55, alignment: .leading)
 
-            // Calibration status
+            // Calibration status: icon-only when the camera picker is there
+            // to give the row context (the dropdown needs the width), icon +
+            // label on rows that would otherwise be unexplained glyphs
+            let showsDropdown = source == .camera && cameraDropdown != nil
             HStack(spacing: 3) {
                 Image(systemName: isCalibrated ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                    .font(.system(size: 9))
-                    .foregroundColor(isCalibrated ? .green : .orange)
-                Text(isCalibrated ? L("settings.calibrated") : L("settings.notCalibrated"))
                     .font(.system(size: 10))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(isCalibrated ? .green : .orange)
+                if !showsDropdown {
+                    Text(isCalibrated ? L("settings.calibrated") : L("settings.notCalibrated"))
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
             }
+            .padding(.horizontal, 2)
+            .frame(minWidth: 18, minHeight: 22)
+            .contentShape(Rectangle())
+            .help(isCalibrated ? L("settings.calibrated") : L("settings.notCalibrated"))
 
             if source == .camera, let dropdown = cameraDropdown {
                 dropdown
@@ -424,6 +604,10 @@ struct DeviceStatusRow: View {
                         .font(.system(size: 10))
                         .foregroundColor(.secondary)
                 }
+                .padding(.horizontal, 2)
+                .frame(minHeight: 22)
+                .contentShape(Rectangle())
+                .help(isConnected ? L("settings.connected") : L("settings.notConnected"))
             }
 
             Spacer(minLength: 0)
@@ -435,19 +619,25 @@ struct DeviceStatusRow: View {
                     .padding(.horizontal, 5)
                     .padding(.vertical, 1)
                     .background(Capsule().fill(Color.brandCyan.opacity(0.12)))
+                    .fixedSize()
             }
 
             // Calibrate button
             Button(action: onCalibrate) {
                 Text(L("settings.recalibrate"))
                     .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(.onBrandCyan)
+                    .foregroundColor(.brandCyan)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
                     .background(
-                        RoundedRectangle(cornerRadius: 4, style: .continuous)
-                            .fill(Color.brandCyan)
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Color.brandCyan.opacity(0.1))
                     )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .strokeBorder(Color.brandCyan.opacity(0.3), lineWidth: 1)
+                    )
+                    .fixedSize()
             }
             .buttonStyle(.plain)
         }
@@ -697,14 +887,18 @@ struct DiscordIcon: View {
 struct HelpButton: View {
     let text: String
     @State private var showingHelp = false
+    @State private var isHovering = false
 
     var body: some View {
         Button(action: { showingHelp.toggle() }) {
             Image(systemName: "questionmark.circle")
                 .font(.system(size: 10))
-                .foregroundColor(.secondary.opacity(0.5))
+                .foregroundColor(.secondary.opacity(isHovering ? 0.8 : 0.35))
+                .frame(width: 18, height: 18)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
         .popover(isPresented: $showingHelp, arrowEdge: .trailing) {
             Text(text)
                 .font(.system(size: 11))

--- a/Sources/UI/SettingsWindow.swift
+++ b/Sources/UI/SettingsWindow.swift
@@ -26,6 +26,7 @@ struct SettingsView: View {
     @State private var warningColor: Color
     @State private var warningOnsetDelay: Double
     @State private var launchAtLogin: Bool
+    @State private var appAppearance: AppAppearance
     #if !APP_STORE
     @State private var autoCheckForUpdates: Bool
     #endif
@@ -95,6 +96,7 @@ struct SettingsView: View {
         _warningColor = State(initialValue: Color(profileWarningColor))
         _warningOnsetDelay = State(initialValue: profileWarningOnsetDelay)
         _launchAtLogin = State(initialValue: SMAppService.mainApp.status == .enabled)
+        _appAppearance = State(initialValue: appDelegate.appAppearance)
         #if !APP_STORE
         _autoCheckForUpdates = State(initialValue: appDelegate.updaterManager?.automaticallyChecksForUpdates ?? false)
         #endif
@@ -170,44 +172,36 @@ struct SettingsView: View {
                         .background(Capsule().fill(Color.primary.opacity(0.05)))
                 }
             }
-            .padding(.bottom, 10)
+            .padding(.bottom, 12)
 
-            SubtleDivider()
+            VStack(spacing: 10) {
 
-            // Tracking section (not part of profile)
-            VStack(spacing: 6) {
-                // Mode row
-                HStack(spacing: 8) {
-                    Text(L("settings.tracking"))
-                        .font(.system(size: 11, weight: .medium))
-                        .frame(width: 82, alignment: .leading)
-
-                    CompactModePicker(selection: $trackingModeSelection)
-                        .frame(width: 150)
-
-                    HelpButton(text: L("settings.tracking.help"))
-                        .onChange(of: trackingModeSelection) { newValue in
-                            Task { @MainActor in
-                                await appDelegate.setTrackingMode(newValue)
-                                activeSource = appDelegate.activeTrackingSource
-                            }
+            // Tracking card: mode picker in the header, source + device below
+            SettingsCard(icon: "scope", title: L("settings.tracking"), helpText: L("settings.tracking.help")) {
+                CompactModePicker(selection: $trackingModeSelection)
+                    .frame(width: 170)
+                    .onChange(of: trackingModeSelection) { newValue in
+                        Task { @MainActor in
+                            await appDelegate.setTrackingMode(newValue)
+                            activeSource = appDelegate.activeTrackingSource
                         }
-
-                    Spacer()
-                }
-                .frame(height: 26)
+                    }
+            } content: {
+                VStack(spacing: 6) {
 
                 if trackingModeSelection == .manual {
                     // Manual mode: source picker + device row for selected source
                     HStack(spacing: 8) {
-                        Text("")
-                            .frame(width: 82)
+                        Text(L("settings.source"))
+                            .font(.system(size: 11))
+
+                        Spacer()
 
                         CompactTrackingSourcePicker(
                             selection: $trackingSource,
                             airPodsAvailable: airPodsAvailable
                         )
-                        .frame(width: 150)
+                        .frame(width: 170)
                         .onChange(of: trackingSource) { newValue in
                             if newValue != appDelegate.trackingSource {
                                 Task { @MainActor in
@@ -215,8 +209,6 @@ struct SettingsView: View {
                                 }
                             }
                         }
-
-                        Spacer()
                     }
                     .frame(height: 26)
 
@@ -233,7 +225,7 @@ struct SettingsView: View {
                                 }
                             }
                             .labelsHidden()
-                            .frame(maxWidth: 140)
+                            .frame(minWidth: 130, maxWidth: 220)
                             .onChange(of: selectedCameraID) { newValue in
                                 if newValue != appDelegate.selectedCameraID {
                                     appDelegate.selectedCameraID = newValue
@@ -252,22 +244,21 @@ struct SettingsView: View {
                         // Preferred source picker
                         HStack(spacing: 8) {
                             Text(L("settings.preferred"))
-                                .font(.system(size: 11, weight: .medium))
-                                .frame(width: 82, alignment: .leading)
+                                .font(.system(size: 11))
+
+                            Spacer()
 
                             CompactTrackingSourcePicker(
                                 selection: $preferredSource,
                                 airPodsAvailable: true
                             )
-                            .frame(width: 150)
+                            .frame(width: 170)
                             .onChange(of: preferredSource) { newValue in
                                 Task { @MainActor in
                                     await appDelegate.setPreferredSource(newValue)
                                     activeSource = appDelegate.activeTrackingSource
                                 }
                             }
-
-                            Spacer()
                         }
                         .frame(height: 26)
 
@@ -285,7 +276,7 @@ struct SettingsView: View {
                                     }
                                 }
                                 .labelsHidden()
-                                .frame(maxWidth: 140)
+                                .frame(minWidth: 130, maxWidth: 220)
                                 .onChange(of: selectedCameraID) { newValue in
                                     if newValue != appDelegate.selectedCameraID {
                                         appDelegate.selectedCameraID = newValue
@@ -332,20 +323,12 @@ struct SettingsView: View {
                         }
                     }
                 }
+                }
             }
-            .padding(.vertical, 10)
 
-            // Profile Section Card
-            VStack(spacing: 6) {
-                // Profile header row - aligned with Warning row below
-                HStack(spacing: 8) {
-                    HStack(spacing: 3) {
-                        Text(L("settings.profile"))
-                            .font(.system(size: 11, weight: .medium))
-                            .frame(width: 82, alignment: .leading)
-                        HelpButton(text: L("settings.profile.help"))
-                    }
-
+            // Posture response card: profile management in the header,
+            // warning style + tuning sliders below
+            SettingsCard(icon: "slider.horizontal.3", title: L("settings.section.response"), helpText: L("settings.profile.help")) {
                     HStack(spacing: 4) {
                         Picker("", selection: $selectedSettingsProfileID) {
                             ForEach(settingsProfiles) { profile in
@@ -354,7 +337,6 @@ struct SettingsView: View {
                         }
                         .labelsHidden()
                         .frame(width: 100)
-                        .padding(.horizontal, -4)
                         .onChange(of: selectedSettingsProfileID) { newValue in
                             handleProfileSelectionChange(newValue)
                         }
@@ -363,43 +345,45 @@ struct SettingsView: View {
                             newProfileName = ""
                             showingNewProfilePrompt = true
                         }) {
-                            HStack(spacing: 4) {
-                                Image(systemName: "plus")
-                                    .font(.system(size: 10, weight: .semibold))
-                                Text(L("settings.profile.new"))
-                                    .font(.system(size: 11, weight: .medium))
-                            }
-                            .foregroundColor(.onBrandCyan)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 5)
-                            .background(
-                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    .fill(Color.brandCyan)
-                            )
+                            Image(systemName: "plus")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundColor(.brandCyan)
+                                .frame(width: 24, height: 20)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                        .fill(Color.brandCyan.opacity(0.1))
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                        .strokeBorder(Color.brandCyan.opacity(0.3), lineWidth: 1)
+                                )
                         }
                         .buttonStyle(.plain)
+                        .help(L("settings.profile.new"))
 
                         // Delete button - only enabled for non-Default profiles when more than one exists
                         Button(action: {
                             showingDeleteConfirmation = true
                         }) {
                             Image(systemName: "trash")
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundColor(canDeleteCurrentProfile ? .white : .secondary)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 5)
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundColor(canDeleteCurrentProfile ? .red.opacity(0.8) : .secondary.opacity(0.4))
+                                .frame(width: 24, height: 20)
                                 .background(
                                     RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                        .fill(canDeleteCurrentProfile ? Color.red : Color.secondary.opacity(0.15))
+                                        .fill(canDeleteCurrentProfile ? Color.red.opacity(0.08) : Color.primary.opacity(0.04))
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                        .strokeBorder(canDeleteCurrentProfile ? Color.red.opacity(0.25) : Color.primary.opacity(0.06), lineWidth: 1)
                                 )
                         }
                         .buttonStyle(.plain)
                         .disabled(!canDeleteCurrentProfile)
+                        .help(L("settings.profile.deleteTitle"))
                     }
-
-                    Spacer()
-                }
-                .frame(height: 26)
+            } content: {
+                VStack(spacing: 6) {
 
                 // Warning row
                 HStack(spacing: 8) {
@@ -417,12 +401,16 @@ struct SettingsView: View {
                             appDelegate.switchWarningMode()
                         }
 
-                    InlineColorPicker(color: $warningColor)
-                        .onChange(of: warningColor) { newValue in
-                            let nsColor = NSColor(newValue)
-                            settingsProfileManager.updateActiveProfile(warningColor: nsColor)
-                            appDelegate.updateWarningColor(nsColor)
-                        }
+                    // Color only applies to the drawn warning styles, so the
+                    // swatch would be dead weight next to Blur/None
+                    if warningMode.usesWarningOverlay {
+                        InlineColorPicker(color: $warningColor)
+                            .onChange(of: warningColor) { newValue in
+                                let nsColor = NSColor(newValue)
+                                settingsProfileManager.updateActiveProfile(warningColor: nsColor)
+                                appDelegate.updateWarningColor(nsColor)
+                            }
+                    }
                 }
                 .frame(height: 26)
 
@@ -483,18 +471,26 @@ struct SettingsView: View {
                     settingsProfileManager.updateActiveProfile(detectionMode: detectionModes[index])
                     appDelegate.applyActiveSettingsProfile()
                 }
+                }
             }
-            .padding(12)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.primary.opacity(0.04))
-            )
 
-            SubtleDivider()
-                .padding(.top, 6)
+            // Behavior card: appearance in the header (matching the other
+            // cards' header-control pattern), app-level toggles below
+            SettingsCard(icon: "switch.2", title: L("settings.section.behavior")) {
+                CompactSegmentedPicker(
+                    selection: $appAppearance,
+                    options: AppAppearance.allCases.map { ($0, $0.displayName) }
+                )
+                .frame(width: 170)
+                .onChange(of: appAppearance) { newValue in
+                    appDelegate.appAppearance = newValue
+                    appDelegate.saveSettings()
+                    appDelegate.applyAppearance()
+                }
+                .help(L("settings.appearance"))
+            } content: {
+                VStack(spacing: 6) {
 
-            // Behavior Section - 2 column grid with fixed widths
-            VStack(spacing: 6) {
                 HStack(spacing: 0) {
                     CompactToggle(
                         title: L("settings.launchAtLogin"),
@@ -531,6 +527,62 @@ struct SettingsView: View {
                     }
                 }
 
+                #if !APP_STORE
+                HStack(spacing: 0) {
+                    CompactToggle(
+                        title: L("settings.autoUpdates"),
+                        helpText: L("settings.autoUpdates.help"),
+                        isOn: $autoCheckForUpdates
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .onChange(of: autoCheckForUpdates) { newValue in
+                        appDelegate.updaterManager?.automaticallyChecksForUpdates = newValue
+                    }
+
+                    CompactToggle(
+                        title: L("settings.compatibilityMode"),
+                        helpText: L("settings.compatibilityMode.help"),
+                        isOn: $useCompatibilityMode
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .onChange(of: useCompatibilityMode) { newValue in
+                        appDelegate.useCompatibilityMode = newValue
+                        appDelegate.saveSettings()
+                        // Clear both blur mechanisms, not just the visual
+                        // effect views: the CGS background blur radius of the
+                        // outgoing private-API path survives alpha resets and
+                        // would otherwise stay on screen indefinitely
+                        appDelegate.clearBlur()
+                    }
+                }
+                #endif
+
+                HStack(spacing: 0) {
+                    CompactToggle(
+                        title: L("settings.pauseOnTheGo"),
+                        helpText: L("settings.pauseOnTheGo.help"),
+                        isOn: $pauseOnTheGo
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .onChange(of: pauseOnTheGo) { newValue in
+                        Task { @MainActor in
+                            await appDelegate.setPauseOnTheGoEnabled(newValue)
+                        }
+                    }
+
+                    CompactToggle(
+                        title: L("settings.pauseOnBattery"),
+                        helpText: L("settings.pauseOnBattery.help"),
+                        isOn: $pauseOnBattery
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .onChange(of: pauseOnBattery) { newValue in
+                        Task { @MainActor in
+                            await appDelegate.setPauseOnBatteryEnabled(newValue)
+                        }
+                    }
+                }
+
                 HStack(spacing: 0) {
                     CompactToggle(
                         title: L("settings.blurWhenAway"),
@@ -547,20 +599,6 @@ struct SettingsView: View {
                     }
 
                     CompactToggle(
-                        title: L("settings.pauseOnTheGo"),
-                        helpText: L("settings.pauseOnTheGo.help"),
-                        isOn: $pauseOnTheGo
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .onChange(of: pauseOnTheGo) { newValue in
-                        Task { @MainActor in
-                            await appDelegate.setPauseOnTheGoEnabled(newValue)
-                        }
-                    }
-                }
-
-                HStack(spacing: 0) {
-                    CompactToggle(
                         title: L("settings.fullScreenOverlay"),
                         helpText: L("settings.fullScreenOverlay.help"),
                         isOn: $useFullScreenOverlay
@@ -571,21 +609,10 @@ struct SettingsView: View {
                         appDelegate.saveSettings()
                         appDelegate.rebuildOverlayWindows()
                     }
-
-                    CompactToggle(
-                        title: L("settings.pauseOnBattery"),
-                        helpText: L("settings.pauseOnBattery.help"),
-                        isOn: $pauseOnBattery
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .onChange(of: pauseOnBattery) { newValue in
-                        Task { @MainActor in
-                            await appDelegate.setPauseOnBatteryEnabled(newValue)
-                        }
-                    }
                 }
 
-                // Shortcut row
+                // Shortcut row (full width so the recorder chip doesn't
+                // disrupt the toggle grid rhythm)
                 HStack(spacing: 0) {
                     CompactShortcutRecorder(
                         shortcut: $toggleShortcut,
@@ -598,47 +625,11 @@ struct SettingsView: View {
                         }
                     )
                     .frame(maxWidth: .infinity, alignment: .leading)
-
-                    #if !APP_STORE
-                    CompactToggle(
-                        title: L("settings.compatibilityMode"),
-                        helpText: L("settings.compatibilityMode.help"),
-                        isOn: $useCompatibilityMode
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .onChange(of: useCompatibilityMode) { newValue in
-                        appDelegate.useCompatibilityMode = newValue
-                        appDelegate.saveSettings()
-                        // Clear both blur mechanisms, not just the visual
-                        // effect views: the CGS background blur radius of the
-                        // outgoing private-API path survives alpha resets and
-                        // would otherwise stay on screen indefinitely
-                        appDelegate.clearBlur()
-                    }
-                    #else
-                    Spacer()
-                        .frame(maxWidth: .infinity)
-                    #endif
                 }
-
-                #if !APP_STORE
-                HStack(spacing: 0) {
-                    CompactToggle(
-                        title: L("settings.autoUpdates"),
-                        helpText: L("settings.autoUpdates.help"),
-                        isOn: $autoCheckForUpdates
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .onChange(of: autoCheckForUpdates) { newValue in
-                        appDelegate.updaterManager?.automaticallyChecksForUpdates = newValue
-                    }
-
-                    Spacer()
-                        .frame(maxWidth: .infinity)
                 }
-                #endif
             }
-            .padding(.vertical, 10)
+
+            }
         }
         .padding(16)
         .frame(width: 480)

--- a/build.sh
+++ b/build.sh
@@ -14,8 +14,8 @@ set -e
 # Configuration
 APP_NAME="Dorso"
 BUNDLE_ID="com.thelazydeveloper.posturr"
-VERSION="1.14.2"
-BUILD_NUMBER="15"
+VERSION="1.15.0"
+BUILD_NUMBER="16"
 MIN_MACOS="13.0"
 
 # Sparkle auto-update (direct-distribution builds only; App Store builds


### PR DESCRIPTION
## Summary

A visual and UX refresh of the Settings window, keeping its compactness while giving it structure, plus a new appearance option.

### Redesign
- Three section cards (Tracking, Posture response, Behavior), each with its primary control in the card header: tracking mode, profile management, and appearance respectively
- Custom stepped slider replaces the system slider: quiet capsule track, brand fill, step dots only for small ranges (Delay previously drew 31 tick marks)
- Slider values in pill badges; buttons in the subtle brand style; camera picker no longer truncates
- Device status is icon-only next to the camera picker and icon + label on rows with no other context; tooltip delay reduced to 250ms with larger hover/click targets
- Warning color swatch only shows for styles that use color (Glow/Border/Solid)
- Toggle grid regrouped logically; the updates/compatibility pair occupies one row that disappears entirely in App Store builds

### New
- Appearance setting: Auto / Light / Dark, persisted and applied live

### Dev affordance
- `--open-settings` launch flag opens Settings directly with tracking and the updater disabled, enabling screenshot-driven UI iteration

## Testing
- Full suite passes headless; App Store flavor compiles clean
- Iterated with window captures across light/dark, manual/automatic, and active/inactive tracking states

🤖 Generated with [Claude Code](https://claude.com/claude-code)