### PR TITLE
Fix appearance switching side effects and toggle tint stability

### DIFF
--- a/Sources/UI/SettingsComponents.swift
+++ b/Sources/UI/SettingsComponents.swift
@@ -186,6 +186,41 @@ struct SteppedSliderTrack: View {
     }
 }
 
+// MARK: - Brand Switch
+
+/// Pure-SwiftUI switch. The AppKit-backed Toggle loses its tint (falling
+/// back to the system accent) whenever NSApp.appearance changes at runtime;
+/// drawing it ourselves keeps the brand color stable and avoids scaling a
+/// native control.
+struct BrandSwitch: View {
+    @Binding var isOn: Bool
+    var isDisabled: Bool = false
+
+    var body: some View {
+        Button(action: { toggle() }) {
+            Capsule()
+                .fill(isOn ? Color.brandCyan : Color.primary.opacity(0.15))
+                .frame(width: 30, height: 18)
+                .overlay(alignment: isOn ? .trailing : .leading) {
+                    Circle()
+                        .fill(.white)
+                        .shadow(color: .black.opacity(0.2), radius: 1, y: 0.5)
+                        .frame(width: 14, height: 14)
+                        .padding(2)
+                }
+        }
+        .buttonStyle(.plain)
+        .opacity(isDisabled ? 0.5 : 1.0)
+    }
+
+    func toggle() {
+        guard !isDisabled else { return }
+        withAnimation(.easeInOut(duration: 0.15)) {
+            isOn.toggle()
+        }
+    }
+}
+
 // MARK: - Compact Toggle
 
 struct CompactToggle: View {
@@ -196,14 +231,8 @@ struct CompactToggle: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Toggle("", isOn: $isOn)
-                .toggleStyle(.switch)
-                .tint(.brandCyan)
-                .labelsHidden()
-                .scaleEffect(0.65)
-                .frame(width: 32)
-                .disabled(isDisabled)
-                .opacity(isDisabled ? 0.5 : 1.0)
+            BrandSwitch(isOn: $isOn, isDisabled: isDisabled)
+                .frame(width: 32, alignment: .leading)
 
             Text(title)
                 .font(.system(size: 11))
@@ -217,7 +246,11 @@ struct CompactToggle: View {
         .frame(height: 22)
         .contentShape(Rectangle())
         .onTapGesture {
-            if !isDisabled { isOn.toggle() }
+            if !isDisabled {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    isOn.toggle()
+                }
+            }
         }
     }
 }
@@ -920,12 +953,8 @@ struct CompactShortcutRecorder: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Toggle("", isOn: $isEnabled)
-                .toggleStyle(.switch)
-                .tint(.brandCyan)
-                .labelsHidden()
-                .scaleEffect(0.65)
-                .frame(width: 32)
+            BrandSwitch(isOn: $isEnabled)
+                .frame(width: 32, alignment: .leading)
                 .onChange(of: isEnabled) { _ in
                     onShortcutChange()
                 }

--- a/Sources/UI/SettingsWindow.swift
+++ b/Sources/UI/SettingsWindow.swift
@@ -478,15 +478,21 @@ struct SettingsView: View {
             // cards' header-control pattern), app-level toggles below
             SettingsCard(icon: "switch.2", title: L("settings.section.behavior")) {
                 CompactSegmentedPicker(
-                    selection: $appAppearance,
+                    // Side effects live in the binding so they run inside the
+                    // click action itself; the custom-drawn controls keep
+                    // their brand colors through the appearance change
+                    selection: Binding(
+                        get: { appAppearance },
+                        set: { newValue in
+                            appDelegate.appAppearance = newValue
+                            appDelegate.saveSettings()
+                            appDelegate.applyAppearance()
+                            appAppearance = newValue
+                        }
+                    ),
                     options: AppAppearance.allCases.map { ($0, $0.displayName) }
                 )
                 .frame(width: 170)
-                .onChange(of: appAppearance) { newValue in
-                    appDelegate.appAppearance = newValue
-                    appDelegate.saveSettings()
-                    appDelegate.applyAppearance()
-                }
                 .help(L("settings.appearance"))
             } content: {
                 VStack(spacing: 6) {

--- a/build.sh
+++ b/build.sh
@@ -14,8 +14,8 @@ set -e
 # Configuration
 APP_NAME="Dorso"
 BUNDLE_ID="com.thelazydeveloper.posturr"
-VERSION="1.15.0"
-BUILD_NUMBER="16"
+VERSION="1.15.1"
+BUILD_NUMBER="17"
 MIN_MACOS="13.0"
 
 # Sparkle auto-update (direct-distribution builds only; App Store builds


### PR DESCRIPTION
## Summary

Two related fixes for the new appearance setting:

- Selecting Light/Dark/Auto could fail to apply or persist: the `.onChange` handler lived inside a subtree that was rebuilt on selection change and was destroyed before firing. Side effects now run inside the picker's binding, during the click itself.
- The toggle switches flipped from brand cyan to the system accent whenever `NSApp.appearance` changed at runtime (AppKit-backed `NSSwitch` drops SwiftUI tint on live appearance changes). Switches are now pure SwiftUI (`BrandSwitch`), consistent with the window's other custom controls: stable color through appearance changes, no flicker, crisper rendering than the previously scaled system control.

## Testing
- Full suite passes headless; App Store flavor compiles clean
- Verified by capture in light and dark, on and off states
- Manually verified: Auto/Light/Dark cycling applies instantly, persists, and keeps toggles green with no flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)